### PR TITLE
7692: CalculateTotalCostPerYear modified to not throw exception on mi…

### DIFF
--- a/src/NHSD.BuyingCatalogue.Ordering.Domain/OrderItem.cs
+++ b/src/NHSD.BuyingCatalogue.Ordering.Domain/OrderItem.cs
@@ -118,7 +118,7 @@ namespace NHSD.BuyingCatalogue.Ordering.Domain
 
         public decimal CalculateTotalCostPerYear()
         {
-            return Price.GetValueOrDefault() * Quantity * (PriceTimeUnit?.AmountInYear ?? EstimationPeriod?.AmountInYear ?? throw new InvalidOperationException("An Order Item must have a Price Time Unit or an Estimation Period"));
+            return Price.GetValueOrDefault() * Quantity * (PriceTimeUnit?.AmountInYear ?? EstimationPeriod?.AmountInYear ?? 1 );
         }
 
         public CostType CostType =>

--- a/tests/NHSD.BuyingCatalogue.Ordering.Domain.UnitTests/OrderItemTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Domain.UnitTests/OrderItemTests.cs
@@ -382,17 +382,19 @@ namespace NHSD.BuyingCatalogue.Ordering.Domain.UnitTests
         }
 
         [Test]
-        public void CalculateCost_WithNoPriceTypeOrEstimationPeriod_ThrowsException()
+        public void CalculateCost_WithNoPriceTypeOrEstimationPeriod_PriceIsPriceTimesQuanitiy()
         {
+            var price = 26;
+            var quantity = 13;
             var orderItem = OrderItemBuilder
                 .Create()
-                .WithPrice(1m)
-                .WithQuantity(10)
+                .WithPrice(price)
+                .WithQuantity(quantity)
                 .WithPriceTimeUnit(null)
                 .WithEstimationPeriod(null)
                 .Build();
 
-            Assert.Throws<InvalidOperationException>(() => orderItem.CalculateTotalCostPerYear());
+            orderItem.CalculateTotalCostPerYear().Should().Be(price * quantity);
         }
 
         [Test]


### PR DESCRIPTION
…ssings estimation period and amount in year, now returns Price * quantity * 1   if periods are not found.
Story [AB#7692](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7692)
Task [AB#8682](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/8682)
