### PR TITLE
Move build images to alpine and specify version

### DIFF
--- a/src/NHSD.BuyingCatalogue.Ordering.Api/Dockerfile
+++ b/src/NHSD.BuyingCatalogue.Ordering.Api/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:latest AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:latest AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 WORKDIR /src
 COPY ["src/NHSD.BuyingCatalogue.Ordering.Api/NHSD.BuyingCatalogue.Ordering.Api.csproj", "src/NHSD.BuyingCatalogue.Ordering.Api/"]
 COPY ["src/NHSD.BuyingCatalogue.Ordering.Common/NHSD.BuyingCatalogue.Ordering.Common.csproj", "src/NHSD.BuyingCatalogue.Ordering.Common/"]

--- a/src/NHSD.BuyingCatalogue.Ordering.OrderingDatabase.Deployment/Dockerfile
+++ b/src/NHSD.BuyingCatalogue.Ordering.OrderingDatabase.Deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:latest AS dacpacbuild
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS dacpacbuild
 WORKDIR ~/dacpac
 COPY src/NHSD.BuyingCatalogue.Ordering.OrderingDatabase.Deployment/*.csproj .
 COPY src/NHSD.BuyingCatalogue.Ordering.OrderingDatabase .


### PR DESCRIPTION
Move build images to use alpine as the base image to avoid the current certificate issues with buster and reduce the image size. Specify the SDK version explicitly so that the correct version of the SDK is always used.