### PR TITLE
Add authorization filters for organisation ID

### DIFF
--- a/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/AuthorizeOrganisationAttribute.cs
+++ b/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/AuthorizeOrganisationAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.Authorization
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public sealed class AuthorizeOrganisationAttribute : Attribute
+    {
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/OrderLookupOrganisationAuthorizationFilter.cs
+++ b/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/OrderLookupOrganisationAuthorizationFilter.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using NHSD.BuyingCatalogue.Ordering.Application.Persistence;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.Authorization
+{
+    internal sealed class OrderLookupOrganisationAuthorizationFilter : OrganisationAuthorizationFilter
+    {
+        internal const string DefaultParameterName = "orderId";
+
+        private readonly IOrderRepository orderRepository;
+
+        public OrderLookupOrganisationAuthorizationFilter(IOrderRepository orderRepository) =>
+            this.orderRepository = orderRepository;
+
+        protected override string ParameterName { get; } = DefaultParameterName;
+
+        // ReSharper disable once RedundantOverriddenMember
+        // There is a bug in the Roslyn analysers library that causes an ArgumentNullException to be thrown
+        // when a class that implements IAsyncAuthorizationFilter does not have an OnAuthorizationAsync symbol
+        // (because it derives from an abstract class as here). This in turn causes an AD0001 warning to be generated
+        // that can't be removed or suppressed without disabling or relaxing the code analysis settings. As we treat
+        // warnings as errors in the release build this causes the release build to fail. Rather than disable warnings
+        // as errors or relax the code analysis settings, this redundant override is included to prevent the exception
+        // in the analyser.
+        // TODO: monitor Roslyn Analyser issue 4772.
+        // Update to fixed version once available (may require use of NuGet version of the library) and remove
+        // redundant override and revert the base method to non-virtual
+        public override Task OnAuthorizationAsync(AuthorizationFilterContext context)
+        {
+            return base.OnAuthorizationAsync(context);
+        }
+
+        protected override async Task<(string Id, IActionResult Result)> GetOrganisationId(string routeValue)
+        {
+            var order = await orderRepository.GetOrderByIdAsync(routeValue, q => q.WithoutTracking());
+            if (order is null)
+                return (null, new NotFoundResult());
+
+            return (order.OrganisationId.ToString(), null);
+        }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/OrganisationAuthorizationFilter.cs
+++ b/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/OrganisationAuthorizationFilter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using NHSD.BuyingCatalogue.Ordering.Common.Constants;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.Authorization
+{
+    internal abstract class OrganisationAuthorizationFilter : IAsyncAuthorizationFilter
+    {
+        protected abstract string ParameterName { get; }
+
+        public virtual async Task OnAuthorizationAsync(AuthorizationFilterContext context)
+        {
+            if (!ActionRequiresHandling(context.ActionDescriptor))
+                return;
+
+            var user = context.HttpContext.User;
+
+            if (!UserHasOrderingClaim(context.HttpContext.User))
+                return;
+
+            (var isSameOrganisation, IActionResult actionResult) = await UserBelongsToRequestOrganisation(
+                user,
+                context.RouteData.Values);
+
+            if (actionResult is not null)
+            {
+                context.Result = actionResult;
+                return;
+            }
+
+            if (!isSameOrganisation)
+                context.Result = new ForbidResult();
+        }
+
+        protected abstract Task<(string Id, IActionResult Result)> GetOrganisationId(string routeValue);
+
+        private static bool UserHasOrderingClaim(ClaimsPrincipal user) => user.HasClaim(c =>
+            string.Equals(c.Type, ApplicationClaimTypes.Ordering, StringComparison.OrdinalIgnoreCase));
+
+        private bool ActionRequiresHandling(ActionDescriptor descriptor)
+        {
+            return descriptor.EndpointMetadata.OfType<AuthorizeOrganisationAttribute>().Any()
+                && descriptor.Parameters.Any(i => i.Name == ParameterName);
+        }
+
+        private async Task<(bool IsSameOrganisation, IActionResult Result)> UserBelongsToRequestOrganisation(
+            ClaimsPrincipal user,
+            RouteValueDictionary routeValues)
+        {
+            (var id, IActionResult result) = await GetOrganisationId(routeValues[ParameterName]?.ToString() ?? string.Empty);
+            if (result is not null)
+                return (false, result);
+
+            var userOrganizationId = user.FindFirstValue(UserClaimTypes.PrimaryOrganisationId);
+            var isSameOrganisation = string.Equals(userOrganizationId, id, StringComparison.OrdinalIgnoreCase);
+
+            return (isSameOrganisation, null);
+        }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/OrganisationIdOrganisationAuthorizationFilter.cs
+++ b/src/NHSD.BuyingCatalogue.Ordering.Api/Authorization/OrganisationIdOrganisationAuthorizationFilter.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.Authorization
+{
+    internal sealed class OrganisationIdOrganisationAuthorizationFilter : OrganisationAuthorizationFilter
+    {
+        internal const string DefaultParameterName = "organisationId";
+
+        protected override string ParameterName { get; } = DefaultParameterName;
+
+        protected override Task<(string Id, IActionResult Result)> GetOrganisationId(string routeValue)
+        {
+            return Task.FromResult<(string, IActionResult)>((routeValue, null));
+        }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Ordering.Api/Controllers/DefaultDeliveryDateController.cs
+++ b/src/NHSD.BuyingCatalogue.Ordering.Api/Controllers/DefaultDeliveryDateController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NHSD.BuyingCatalogue.Ordering.Api.Authorization;
 using NHSD.BuyingCatalogue.Ordering.Api.Models;
 using NHSD.BuyingCatalogue.Ordering.Api.Models.Errors;
 using NHSD.BuyingCatalogue.Ordering.Api.Validation;
@@ -17,6 +18,7 @@ namespace NHSD.BuyingCatalogue.Ordering.Api.Controllers
     [ApiController]
     [Produces(MediaTypeNames.Application.Json)]
     [Authorize(Policy = PolicyName.CanAccessOrders)]
+    [AuthorizeOrganisation]
     public sealed class DefaultDeliveryDateController : ControllerBase
     {
         private readonly IOrderRepository orderRepository;

--- a/src/NHSD.BuyingCatalogue.Ordering.Common/Constants/UserClaimTypes.cs
+++ b/src/NHSD.BuyingCatalogue.Ordering.Common/Constants/UserClaimTypes.cs
@@ -1,0 +1,7 @@
+﻿namespace NHSD.BuyingCatalogue.Ordering.Common.Constants
+{
+    public static class UserClaimTypes
+    {
+        public const string PrimaryOrganisationId = "primaryOrganisationId";
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.IntegrationTests/Features/Default Delivery Date Get.feature
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.IntegrationTests/Features/Default Delivery Date Get.feature
@@ -51,6 +51,14 @@ Scenario: A non buyer user cannot get a default delivery date
     Then a response with status code 403 is returned
 
 @8952
+Scenario: A buyer user cannot get the default delivery of an order for an organisation they don't belong to
+    Given the user is logged in with the Buyer role for organisation e6ea864e-ef1b-41aa-a4d5-04fc6fce0933
+    When the user gets the default delivery date for the catalogue item with the following details
+        | OrderId    | CatalogueItemId | PriceId |
+        | C000014-01 | 10001-001       | 1       |
+    Then a response with status code 403 is returned
+
+@8952
 Scenario: A service failure causes the expected response to be returned when getting a default delivery date
     Given the call to the database will fail
     When the user gets the default delivery date for the catalogue item with the following details

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.IntegrationTests/Features/Default Delivery Date Put.feature
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.IntegrationTests/Features/Default Delivery Date Put.feature
@@ -125,6 +125,15 @@ Scenario: Set a default delivery date five years after the commencement date of 
         | DeliveryDateOutsideDeliveryWindow | DeliveryDate  |
 
 @8952
+Scenario: A buyer user cannot set the default delivery of an order for an organisation they don't belong to
+    Given the user is logged in with the Buyer role for organisation e6ea864e-ef1b-41aa-a4d5-04fc6fce0933
+    And the user sets the default delivery date using the following details
+        | OrderId    | CatalogueItemId | PriceId | DeliveryDate |
+        | C000014-02 | 10001-001       | 1       | 31/10/2020   |
+    When the user confirms the default delivery date
+    Then a response with status code 403 is returned
+
+@8952
 Scenario: A service failure causes the expected response to be returned when setting a default delivery date
     Given the call to the database will fail
     And the user sets the default delivery date using the following details

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/AuthorizationFilterContextBuilder.cs
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/AuthorizationFilterContextBuilder.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Authorization
+{
+    internal sealed class AuthorizationFilterContextBuilder
+    {
+        private readonly HttpContext httpContext = new DefaultHttpContext();
+        private readonly RouteValueDictionary routeValues = new();
+
+        private ActionDescriptor actionDescriptor = new();
+
+        private AuthorizationFilterContextBuilder()
+        {
+        }
+
+        internal static AuthorizationFilterContextBuilder Create() => new();
+
+        internal AuthorizationFilterContextBuilder WithActionDescription(ActionDescriptor descriptor)
+        {
+            actionDescriptor = descriptor;
+            return this;
+        }
+
+        internal AuthorizationFilterContextBuilder WithRouteValue(string key, string value)
+        {
+            routeValues.Add(key, value);
+            return this;
+        }
+
+        internal AuthorizationFilterContextBuilder WithUser(ClaimsPrincipal user)
+        {
+            httpContext.User = user;
+            return this;
+        }
+
+        internal AuthorizationFilterContext Build()
+        {
+            return new(
+                new ActionContext(httpContext, new RouteData(routeValues), actionDescriptor, new ModelStateDictionary()),
+                new List<IFilterMetadata>());
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/ClaimsPrincipalBuilder.cs
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/ClaimsPrincipalBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Authorization
+{
+    internal sealed class ClaimsPrincipalBuilder
+    {
+        private readonly List<Claim> claims = new();
+
+        private ClaimsPrincipalBuilder()
+        {
+        }
+
+        internal static ClaimsPrincipalBuilder Create() => new();
+
+        internal ClaimsPrincipalBuilder WithClaim(string type, string value = "")
+        {
+            claims.Add(new Claim(type, value));
+            return this;
+        }
+
+        internal ClaimsPrincipal Build() => new(new ClaimsIdentity(claims, "mock"));
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/OrderLookupOrganisationAuthorizationFilterTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/OrderLookupOrganisationAuthorizationFilterTests.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Moq;
+using NHSD.BuyingCatalogue.Ordering.Api.Authorization;
+using NHSD.BuyingCatalogue.Ordering.Api.UnitTests.AutoFixture;
+using NHSD.BuyingCatalogue.Ordering.Application.Persistence;
+using NHSD.BuyingCatalogue.Ordering.Common.Constants;
+using NHSD.BuyingCatalogue.Ordering.Domain;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Authorization
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    [SuppressMessage("ReSharper", "NUnit.MethodWithParametersAndTestAttribute", Justification = "False positive")]
+    internal static class OrderLookupOrganisationAuthorizationFilterTests
+    {
+        [Test]
+        [OrderingAutoData]
+        public static async Task OnAuthorizationAsync_OrderNotFound_ReturnsExpectedValue(
+            OrderLookupOrganisationAuthorizationFilter filter)
+        {
+            const string parameterName = OrderLookupOrganisationAuthorizationFilter.DefaultParameterName;
+
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId)
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = parameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(parameterName, "InvalidOrderId")
+                .WithUser(user)
+                .Build();
+
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().NotBeNull();
+            context.Result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Test]
+        [OrderingAutoData]
+        public static async Task OnAuthorizationAsync_LooksUpExpectedOrderId(
+            string orderId,
+            [Frozen] Mock<IOrderRepository> orderRepositoryMock,
+            OrderLookupOrganisationAuthorizationFilter filter)
+        {
+            const string parameterName = OrderLookupOrganisationAuthorizationFilter.DefaultParameterName;
+
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId)
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = parameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(parameterName, orderId)
+                .WithUser(user)
+                .Build();
+
+            await filter.OnAuthorizationAsync(context);
+
+            orderRepositoryMock.Verify(r => r.GetOrderByIdAsync(
+                It.Is<string>(s => s == orderId),
+                It.IsNotNull<Action<IOrderQuery>>()));
+        }
+
+        [Test]
+        [OrderingAutoData]
+        public static async Task OnAuthorizationAsync_UsesExpectedOrderQuery(
+            Mock<IOrderQuery> orderQueryMock,
+            [Frozen] Mock<IOrderRepository> orderRepositoryMock,
+            OrderLookupOrganisationAuthorizationFilter filter)
+        {
+            const string parameterName = OrderLookupOrganisationAuthorizationFilter.DefaultParameterName;
+
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId)
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = parameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(parameterName, string.Empty)
+                .WithUser(user)
+                .Build();
+
+            Action<IOrderQuery> queryConfigured = null;
+            orderRepositoryMock
+                .Setup(r => r.GetOrderByIdAsync(It.IsAny<string>(), It.IsNotNull<Action<IOrderQuery>>()))
+                .Callback<string, Action<IOrderQuery>>((_, configureQuery) => queryConfigured = configureQuery);
+
+            await filter.OnAuthorizationAsync(context);
+            queryConfigured(orderQueryMock.Object);
+
+            orderQueryMock.Verify(q => q.WithoutTracking());
+            orderQueryMock.VerifyNoOtherCalls();
+        }
+
+        [Test]
+        [OrderingAutoData]
+        public static async Task OnAuthorizationAsync_UserHasSamePrimaryOrganisationId_ReturnsExpectedValue(
+            Order order,
+            [Frozen] Mock<IOrderRepository> orderRepositoryMock,
+            OrderLookupOrganisationAuthorizationFilter filter)
+        {
+            const string parameterName = OrderLookupOrganisationAuthorizationFilter.DefaultParameterName;
+            var orderId = order.OrderId;
+
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId, order.OrganisationId.ToString())
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = parameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(parameterName, orderId)
+                .WithUser(user)
+                .Build();
+
+            orderRepositoryMock
+                .Setup(r => r.GetOrderByIdAsync(It.Is<string>(s => s == orderId), It.IsNotNull<Action<IOrderQuery>>()))
+                .ReturnsAsync(order);
+
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().BeNull();
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/OrganisationAuthorizationFilterTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/OrganisationAuthorizationFilterTests.cs
@@ -1,0 +1,244 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using NHSD.BuyingCatalogue.Ordering.Api.Authorization;
+using NHSD.BuyingCatalogue.Ordering.Common.Constants;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Authorization
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    [SuppressMessage("ReSharper", "NUnit.MethodWithParametersAndTestAttribute", Justification = "False positive")]
+    internal static class OrganisationAuthorizationFilterTests
+    {
+        private const string RouteParameterName = "aParameter";
+
+        [Test]
+        public static async Task OnAuthorizationAsync_NoAttribute_ReturnsExpectedValue()
+        {
+            var context = AuthorizationFilterContextBuilder.Create().Build();
+
+            var result = new OkResult();
+            context.Result = result;
+
+            var filter = new TestFilter();
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().Be(result);
+        }
+
+        [Test]
+        public static async Task OnAuthorizationAsync_NoParameter_ReturnsExpectedValue()
+        {
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .Build();
+
+            var filter = new TestFilter();
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().BeNull();
+        }
+
+        [Test]
+        public static async Task OnAuthorizationAsync_NoUser_ReturnsExpectedValue()
+        {
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = RouteParameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .Build();
+
+            var result = new OkResult();
+            context.Result = result;
+
+            var filter = new TestFilter();
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().Be(result);
+        }
+
+        [Test]
+        public static async Task OnAuthorizationAsync_UserHasNoOrderingClaim_ReturnsExpectedValue()
+        {
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = RouteParameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithUser(new ClaimsPrincipal())
+                .Build();
+
+            var filter = new TestFilter();
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().BeNull();
+        }
+
+        [Test]
+        [AutoData]
+        public static async Task OnAuthorizationAsync_RouteValue_IsExpectedValue(string routeValue)
+        {
+            var user = ClaimsPrincipalBuilder.Create().WithClaim(ApplicationClaimTypes.Ordering).Build();
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = RouteParameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(RouteParameterName, routeValue)
+                .WithUser(user)
+                .Build();
+
+            var filter = new TestFilter();
+            await filter.OnAuthorizationAsync(context);
+
+            filter.RouteValue.Should().Be(routeValue);
+        }
+
+        [Test]
+        public static async Task OnAuthorizationAsync_ImplementationReturnsActionResult_ReturnsExpectedValue()
+        {
+            var user = ClaimsPrincipalBuilder.Create().WithClaim(ApplicationClaimTypes.Ordering).Build();
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = RouteParameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(RouteParameterName, null)
+                .WithUser(user)
+                .Build();
+
+            var result = new OkResult();
+            context.Result = result;
+            var expectedResult = new NoContentResult();
+
+            var filter = new TestFilter { Result = expectedResult };
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [AutoData]
+        public static async Task OnAuthorizationAsync_UserHasNoPrimaryOrganisationIdClaim_ReturnsExpectedValue(
+            string organisationId)
+        {
+            var user = ClaimsPrincipalBuilder.Create().WithClaim(ApplicationClaimTypes.Ordering).Build();
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = RouteParameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(RouteParameterName, null)
+                .WithUser(user)
+                .Build();
+
+            var filter = new TestFilter { Id = organisationId };
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().NotBeNull();
+            context.Result.Should().BeOfType<ForbidResult>();
+        }
+
+        [Test]
+        [AutoData]
+        public static async Task OnAuthorizationAsync_UserHasDifferentPrimaryOrganisationId_ReturnsExpectedValue(
+            string organisationId1,
+            string organisationId2)
+        {
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId, organisationId1)
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = RouteParameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(RouteParameterName, null)
+                .WithUser(user)
+                .Build();
+
+            var filter = new TestFilter { Id = organisationId2 };
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().NotBeNull();
+            context.Result.Should().BeOfType<ForbidResult>();
+        }
+
+        [Test]
+        [AutoData]
+        public static async Task OnAuthorizationAsync_UserHasSamePrimaryOrganisationId_ReturnsExpectedValue(
+            string organisationId)
+        {
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId, organisationId)
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = RouteParameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(RouteParameterName, null)
+                .WithUser(user)
+                .Build();
+
+            var filter = new TestFilter { Id = organisationId };
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().BeNull();
+        }
+
+        private sealed class TestFilter : OrganisationAuthorizationFilter
+        {
+            internal string Id { get; init; }
+
+            internal IActionResult Result { get; init; }
+
+            internal string RouteValue { get; private set; }
+
+            protected override string ParameterName { get; } = RouteParameterName;
+
+            protected override Task<(string Id, IActionResult Result)> GetOrganisationId(string routeValue)
+            {
+                RouteValue = routeValue;
+                return Task.FromResult((Id, Result));
+            }
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/OrganisationIdOrganisationAuthorizationFilterTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Authorization/OrganisationIdOrganisationAuthorizationFilterTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using NHSD.BuyingCatalogue.Ordering.Api.Authorization;
+using NHSD.BuyingCatalogue.Ordering.Api.UnitTests.AutoFixture;
+using NHSD.BuyingCatalogue.Ordering.Common.Constants;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Authorization
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    [SuppressMessage("ReSharper", "NUnit.MethodWithParametersAndTestAttribute", Justification = "False positive")]
+    internal static class OrganisationIdOrganisationAuthorizationFilterTests
+    {
+        [Test]
+        [OrderingAutoData]
+        public static async Task OnAuthorizationAsync_UserHasDifferentPrimaryOrganisationId_ReturnsExpectedValue(
+            string organisationId,
+            OrganisationIdOrganisationAuthorizationFilter filter)
+        {
+            const string parameterName = OrganisationIdOrganisationAuthorizationFilter.DefaultParameterName;
+
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId)
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = parameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(parameterName, organisationId)
+                .WithUser(user)
+                .Build();
+
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().NotBeNull();
+            context.Result.Should().BeOfType<ForbidResult>();
+        }
+
+        [Test]
+        [OrderingAutoData]
+        public static async Task OnAuthorizationAsync_UserHasSamePrimaryOrganisationId_ReturnsExpectedValue(
+            string organisationId,
+            OrganisationIdOrganisationAuthorizationFilter filter)
+        {
+            const string parameterName = OrganisationIdOrganisationAuthorizationFilter.DefaultParameterName;
+
+            var user = ClaimsPrincipalBuilder.Create()
+                .WithClaim(ApplicationClaimTypes.Ordering)
+                .WithClaim(UserClaimTypes.PrimaryOrganisationId, organisationId)
+                .Build();
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new object[] { new AuthorizeOrganisationAttribute() },
+                Parameters = new[] { new ParameterDescriptor { Name = parameterName } },
+            };
+
+            var context = AuthorizationFilterContextBuilder.Create()
+                .WithActionDescription(actionDescriptor)
+                .WithRouteValue(parameterName, organisationId)
+                .WithUser(user)
+                .Build();
+
+            await filter.OnAuthorizationAsync(context);
+
+            context.Result.Should().BeNull();
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Controllers/OrdersControllerTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Ordering.Api.UnitTests/Controllers/OrdersControllerTests.cs
@@ -54,18 +54,6 @@ namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Controllers
         }
 
         [Test]
-        public static async Task GetAsync_WrongOrganisationId_ReturnsForbidden()
-        {
-            var context = OrdersControllerTestContext.Setup();
-
-            const string orderId = "C0000014-01";
-            context.Order = CreateGetTestData(orderId, Guid.NewGuid(), "ods").Order;
-
-            var response = await context.OrdersController.GetAsync(orderId);
-            response.Result.Should().BeOfType<ForbidResult>();
-        }
-
-        [Test]
         public static async Task GetAsync_OrderExists_ReturnsResult()
         {
             var context = OrdersControllerTestContext.Setup();
@@ -111,25 +99,6 @@ namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Controllers
             var ordersResult = result.Value;
             ordersResult.Should().ContainSingle();
             ordersResult.Should().BeEquivalentTo(orders.Select(t => t.Expected));
-        }
-
-        [Test]
-        public static async Task GetAllAsync_SingleOrderWithOtherOrganisationIdExists_ReturnsForbidden()
-        {
-            var otherOrganisationId = Guid.NewGuid();
-            var context = OrdersControllerTestContext.Setup();
-            var orders = new List<(Order Order, OrderListItemModel Expected)>
-            {
-                CreateOrderTestData("C0000014-01", otherOrganisationId, "A description"),
-            };
-
-            context.Orders = orders.Select(t => t.Order);
-
-            var controller = context.OrdersController;
-
-            var result = await controller.GetAllAsync(otherOrganisationId);
-            result.Should().NotBeNull();
-            result.Result.Should().BeOfType<ForbidResult>();
         }
 
         [Test]
@@ -559,18 +528,6 @@ namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Controllers
         }
 
         [Test]
-        public static async Task DeleteOrderAsync_OrderForDifferentOrganisation_ReturnsForbidden()
-        {
-            var context = OrdersControllerTestContext.Setup();
-            context.Order = OrderBuilder.Create()
-                .WithOrganisationId(Guid.NewGuid())
-                .Build();
-
-            var response = await context.OrdersController.DeleteOrderAsync("Order");
-            response.Should().BeOfType<ForbidResult>();
-        }
-
-        [Test]
         public static void UpdateStatusAsync_NullModel_ThrowsException()
         {
             var context = OrdersControllerTestContext.Setup();
@@ -585,18 +542,6 @@ namespace NHSD.BuyingCatalogue.Ordering.Api.UnitTests.Controllers
 
             var response = await context.OrdersController.UpdateStatusAsync("Order", context.CompleteOrderStatusModel);
             response.Result.Should().BeOfType<NotFoundResult>();
-        }
-
-        [Test]
-        public static async Task UpdateStatusAsync_OrderForDifferentOrganisation_ReturnsBadRequest()
-        {
-            var context = OrdersControllerTestContext.Setup();
-            context.Order = OrderBuilder.Create()
-                .WithOrganisationId(Guid.NewGuid())
-                .Build();
-
-            var response = await context.OrdersController.UpdateStatusAsync("Order", context.CompleteOrderStatusModel);
-            response.Result.Should().BeOfType<ForbidResult>();
         }
 
         [TestCase(null)]


### PR DESCRIPTION
Activity: [AB#11802](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/11802)
Task: [AB#11803](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/11803)

Adds authorization filters that will check whether a buyer is authorized to view/edit a particular order. This allows duplicated code that performs the same check to be removed from almost every controller method as well as the respective tests. This particular PR only updates the `DeliveryDateController` and `OrdersController` controllers to avoid the PR from becoming too large. Additional tasks will be raised to update the remaining controllers and their tests.

This introduces an additional DB request but given the relatively low number of existing DB calls and relatively small anticipated user base I doubt this will have much of a noticeable performance impact. Caching is always an option we can look into later if required.

Tech debt [task 11896](https://dev.azure.com/BuyingCatalog/Buying%20Catalogue/_workitems/edit/11896) created to monitor the Roslyn analyser issue (see comments in `OrderLookupOrganisationAuthorizationFilter`).