### PR TITLE
Add bulk migration package

### DIFF
--- a/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/Migrate.dtsx
+++ b/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/Migrate.dtsx
@@ -1,0 +1,10163 @@
+﻿<?xml version="1.0"?>
+<DTS:Executable xmlns:DTS="www.microsoft.com/SqlServer/Dts"
+  DTS:refId="Package"
+  DTS:CreationDate="5/20/2021 12:54:48 PM"
+  DTS:CreationName="Microsoft.Package"
+  DTS:CreatorComputerName="LPT4491"
+  DTS:CreatorName="BJSS\christopher.martin"
+  DTS:DTSID="{9F73416D-1D82-4D42-8777-E7030FF375E6}"
+  DTS:ExecutableType="Microsoft.Package"
+  DTS:LastModifiedProductVersion="15.0.2000.166"
+  DTS:LocaleID="2057"
+  DTS:ObjectName="Package"
+  DTS:PackageType="5"
+  DTS:ProtectionLevel="0"
+  DTS:VersionBuild="171"
+  DTS:VersionGUID="{89EA8F7D-BD01-4B82-9C47-0C892922BF7A}">
+  <DTS:Property
+    DTS:Name="PackageFormatVersion">8</DTS:Property>
+  <DTS:ConnectionManagers>
+    <DTS:ConnectionManager
+      DTS:refId="Package.ConnectionManagers[BuyingCatalogue]"
+      DTS:CreationName="OLEDB"
+      DTS:DTSID="{D5DA022B-D1B7-4FAD-A65D-38D6665ED541}"
+      DTS:ObjectName="BuyingCatalogue">
+      <DTS:PropertyExpression
+        DTS:Name="InitialCatalog">@[$Package::DatabaseName_BuyingCatalogue]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="Password">@[$Package::Password]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="ServerName">@[$Package::Host]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="UserName">@[$Package::UserName]</DTS:PropertyExpression>
+      <DTS:ObjectData>
+        <DTS:ConnectionManager
+          DTS:ConnectRetryCount="1"
+          DTS:ConnectRetryInterval="5"
+          DTS:ConnectionString="Data Source=localhost;User ID=user_name;Initial Catalog=BuyingCatalogue;Provider=SQLNCLI11.1;Auto Translate=False;">
+          <DTS:Password
+            DTS:Name="Password"
+            Sensitive="1"></DTS:Password>
+        </DTS:ConnectionManager>
+      </DTS:ObjectData>
+    </DTS:ConnectionManager>
+    <DTS:ConnectionManager
+      DTS:refId="Package.ConnectionManagers[Ordering_Bulk]"
+      DTS:CreationName="OLEDB"
+      DTS:DTSID="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+      DTS:ObjectName="Ordering_Bulk">
+      <DTS:PropertyExpression
+        DTS:Name="InitialCatalog">@[$Package::DatabaseName_Ordering_Bulk]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="Password">@[$Package::Password]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="ServerName">@[$Package::Host]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="UserName">@[$Package::UserName]</DTS:PropertyExpression>
+      <DTS:ObjectData>
+        <DTS:ConnectionManager
+          DTS:Retain="True"
+          DTS:ConnectRetryCount="1"
+          DTS:ConnectRetryInterval="5"
+          DTS:ConnectionString="Data Source=localhost;User ID=user_name;Initial Catalog=BuyingCatalogueOrdering_Bulk;Provider=SQLNCLI11.1;Auto Translate=False;">
+          <DTS:Password
+            DTS:Name="Password"
+            Sensitive="1"></DTS:Password>
+        </DTS:ConnectionManager>
+      </DTS:ObjectData>
+    </DTS:ConnectionManager>
+    <DTS:ConnectionManager
+      DTS:refId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+      DTS:CreationName="OLEDB"
+      DTS:DTSID="{200CEF1E-4EB0-48F8-9FCC-B07A263D9CA6}"
+      DTS:ObjectName="Ordering_Non-Bulk">
+      <DTS:PropertyExpression
+        DTS:Name="InitialCatalog">@[$Package::DatabaseName_Ordering_Non_Bulk]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="Password">@[$Package::Password]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="ServerName">@[$Package::Host]</DTS:PropertyExpression>
+      <DTS:PropertyExpression
+        DTS:Name="UserName">@[$Package::UserName]</DTS:PropertyExpression>
+      <DTS:ObjectData>
+        <DTS:ConnectionManager
+          DTS:Retain="True"
+          DTS:ConnectRetryCount="1"
+          DTS:ConnectRetryInterval="5"
+          DTS:ConnectionString="Data Source=localhost;User ID=user_name;Initial Catalog=BuyingCatalogueOrdering_Non-Bulk;Provider=SQLNCLI11.1;Auto Translate=False;">
+          <DTS:Password
+            DTS:Name="Password"
+            Sensitive="1"></DTS:Password>
+        </DTS:ConnectionManager>
+      </DTS:ObjectData>
+    </DTS:ConnectionManager>
+  </DTS:ConnectionManagers>
+  <DTS:PackageParameters>
+    <DTS:PackageParameter
+      DTS:CreationName=""
+      DTS:DataType="8"
+      DTS:DTSID="{01A4A307-CE48-4D56-B63F-F13E43519E0B}"
+      DTS:ObjectName="DatabaseName_BuyingCatalogue"
+      DTS:Required="True">
+      <DTS:Property
+        DTS:DataType="8"
+        DTS:Name="ParameterValue">BuyingCatalogue</DTS:Property>
+    </DTS:PackageParameter>
+    <DTS:PackageParameter
+      DTS:CreationName=""
+      DTS:DataType="8"
+      DTS:DTSID="{CC7BC7C2-17AD-424E-91E3-E983126A12E8}"
+      DTS:ObjectName="DatabaseName_Ordering_Bulk"
+      DTS:Required="True">
+      <DTS:Property
+        DTS:DataType="8"
+        DTS:Name="ParameterValue">BuyingCatalogueOrdering_Bulk</DTS:Property>
+    </DTS:PackageParameter>
+    <DTS:PackageParameter
+      DTS:CreationName=""
+      DTS:DataType="8"
+      DTS:DTSID="{AD238A10-7C09-4B11-A5ED-503386803842}"
+      DTS:ObjectName="DatabaseName_Ordering_Non_Bulk"
+      DTS:Required="True">
+      <DTS:Property
+        DTS:DataType="8"
+        DTS:Name="ParameterValue">BuyingCatalogueOrdering_Non-Bulk</DTS:Property>
+    </DTS:PackageParameter>
+    <DTS:PackageParameter
+      DTS:CreationName=""
+      DTS:DataType="8"
+      DTS:DTSID="{DE1EB755-3C39-4820-B7A2-59914BF36E14}"
+      DTS:ObjectName="Host"
+      DTS:Required="True">
+      <DTS:Property
+        DTS:DataType="8"
+        DTS:Name="ParameterValue">localhost</DTS:Property>
+    </DTS:PackageParameter>
+    <DTS:PackageParameter
+      DTS:CreationName=""
+      DTS:DataType="8"
+      DTS:DTSID="{76A71118-0FE5-4238-AE38-DD443DF8AEDA}"
+      DTS:ObjectName="Password"
+      DTS:Required="True"
+      DTS:Sensitive="True">
+      <DTS:Property
+        DTS:Name="ParameterValue">
+        <DTS:Property
+          DTS:DataType="0"
+          DTS:Name="ParameterValue"></DTS:Property>
+      </DTS:Property>
+    </DTS:PackageParameter>
+    <DTS:PackageParameter
+      DTS:CreationName=""
+      DTS:DataType="8"
+      DTS:DTSID="{1CAB2FC2-2845-407F-9379-F26F8841FE3F}"
+      DTS:ObjectName="UserName"
+      DTS:Required="True">
+      <DTS:Property
+        DTS:DataType="8"
+        DTS:Name="ParameterValue">user_name</DTS:Property>
+    </DTS:PackageParameter>
+  </DTS:PackageParameters>
+  <DTS:Variables>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{87E1813E-765E-464E-A7C3-CADF853DE025}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;INSERT INTO dbo.Contact(FirstName, LastName, Email, Phone)&#xA;SELECT FirstName, LastName, Email, Phone&#xA;  FROM &quot; + @[User::contactsTempTableName]  + &quot;&#xA; WHERE Id = ?;&#xA;&#xA;SELECT SCOPE_IDENTITY();&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="addContactDataSql">
+      <DTS:VariableValue
+        DTS:DataType="8">INSERT INTO dbo.Contact(FirstName, LastName, Email, Phone)
+SELECT FirstName, LastName, Email, Phone
+  FROM ##Contacts
+ WHERE Id = ?;
+
+SELECT SCOPE_IDENTITY();</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{B96ADA79-FB2E-43D4-AA19-6B536E4887ED}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;INSERT INTO dbo.[Address] (Line1, Line2, Line3, Line4, Line5,&#xA;       Town, County, Postcode, Country)&#xA;SELECT Line1, Line2, Line3, Line4, Line5,&#xA;       Town, County, Postcode, Country&#xA;  FROM &quot; + @[User::addressesTempTableName]  + &quot;&#xA; WHERE OrganizationId = ?;&#xA;&#xA; SELECT SCOPE_IDENTITY();&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="addOrganizationAddressDataSql">
+      <DTS:VariableValue
+        DTS:DataType="8">INSERT INTO dbo.[Address] (Line1, Line2, Line3, Line4, Line5,
+       Town, County, Postcode, Country)
+SELECT Line1, Line2, Line3, Line4, Line5,
+       Town, County, Postcode, Country
+  FROM ##OrganizationAddresses
+ WHERE OrganizationId = ?;
+
+ SELECT SCOPE_IDENTITY();</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{D71D8F14-19CE-450C-A920-D35BC151E552}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="addressesTempTableName">
+      <DTS:VariableValue
+        DTS:DataType="8">##OrganizationAddresses</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{BAF49263-D7C0-4789-8B18-793BAA7D1D3B}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;INSERT INTO dbo.[Address] (Line1, Line2, Line3, Line4, Line5,&#xA;       Town, County, Postcode, Country)&#xA;SELECT Line1, Line2, Line3, Line4, Line5,&#xA;       Town, County, Postcode, Country&#xA;  FROM &quot; + @[User::supplierAddressesTempTableName]  + &quot;&#xA; WHERE SupplierId = ?;&#xA;&#xA; SELECT SCOPE_IDENTITY();&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="addSupplierAddressDataSql">
+      <DTS:VariableValue
+        DTS:DataType="8">INSERT INTO dbo.[Address] (Line1, Line2, Line3, Line4, Line5,
+       Town, County, Postcode, Country)
+SELECT Line1, Line2, Line3, Line4, Line5,
+       Town, County, Postcode, Country
+  FROM ##SupplierAddresses
+ WHERE SupplierId = ?;
+
+ SELECT SCOPE_IDENTITY();</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{A5F69FC7-DA6F-4F4F-A3DE-35D4F79051C5}"
+      DTS:IncludeInDebugDump="6789"
+      DTS:Namespace="User"
+      DTS:ObjectName="contactId">
+      <DTS:VariableValue
+        DTS:DataType="3">0</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{2185D77C-C007-48FB-AA7C-7408697F6B8C}"
+      DTS:IncludeInDebugDump="6789"
+      DTS:Namespace="User"
+      DTS:ObjectName="contactIdentityValue">
+      <DTS:VariableValue
+        DTS:DataType="3">0</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{00479F39-3EE0-4AD1-AC9F-3C1D20F29CEF}"
+      DTS:IncludeInDebugDump="6789"
+      DTS:Namespace="User"
+      DTS:ObjectName="contactIDs">
+      <DTS:VariableValue
+        DTS:DataSubType="ManagedSerializable"
+        DTS:DataType="13">
+        <SOAP-ENV:Envelope xmlns:clr="http://schemas.microsoft.com/soap/encoding/clr/1.0" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+          <SOAP-ENV:Body>
+            <xsd:anyType
+              id="ref-1"></xsd:anyType>
+          </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+      </DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{C16723CF-ACA4-4A51-A6D0-5CFD0FA98A0E}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="contactsTempTableName">
+      <DTS:VariableValue
+        DTS:DataType="8">##Contacts</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{A98DB6F5-19DC-47E4-B5F0-181C9AE2D49A}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;CREATE TABLE &quot; + @[User::addressesTempTableName] + &quot;&#xA;(&#xA;    OrganizationId uniqueidentifier PRIMARY KEY,&#xA;    Line1 nvarchar(256) NOT NULL,&#xA;    Line2 nvarchar(256) NULL,&#xA;    Line3 nvarchar(256) NULL,&#xA;    Line4 nvarchar(256) NULL,&#xA;    Line5 nvarchar(256) NULL,&#xA;    Town nvarchar(256) NULL,&#xA;    County nvarchar(256) NULL,&#xA;    Postcode nvarchar(10) NOT NULL,&#xA;    Country nvarchar(256) NULL&#xA;);&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="createAddressesTempTableSql">
+      <DTS:VariableValue
+        DTS:DataType="8">CREATE TABLE ##OrganizationAddresses
+(
+    OrganizationId uniqueidentifier PRIMARY KEY,
+    Line1 nvarchar(256) NOT NULL,
+    Line2 nvarchar(256) NULL,
+    Line3 nvarchar(256) NULL,
+    Line4 nvarchar(256) NULL,
+    Line5 nvarchar(256) NULL,
+    Town nvarchar(256) NULL,
+    County nvarchar(256) NULL,
+    Postcode nvarchar(10) NOT NULL,
+    Country nvarchar(256) NULL
+);</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{AF5207B3-B0EF-4E92-8BEB-19D5A6EF4588}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;CREATE TABLE &quot; + @[User::contactsTempTableName]   + &quot;&#xA;(&#xA;    Id int NOT NULL PRIMARY KEY,&#xA;    FirstName nvarchar(100) NULL,&#xA;    LastName nvarchar(100) NULL,&#xA;    Email nvarchar(256) NULL,&#xA;    Phone nvarchar(35) NULL&#xA;);&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="createContactsTempTableSql">
+      <DTS:VariableValue
+        DTS:DataType="8">CREATE TABLE ##Contacts
+(
+    Id int NOT NULL PRIMARY KEY,
+    FirstName nvarchar(100) NULL,
+    LastName nvarchar(100) NULL,
+    Email nvarchar(256) NULL,
+    Phone nvarchar(35) NULL
+);</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{5CC26501-0374-4EF9-B906-F0C86BCC9DDF}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;CREATE TABLE &quot; + @[User::orderContactsTempTableName]  + &quot;&#xA;(&#xA;    OrderId int NOT NULL PRIMARY KEY,&#xA;    OrganizationContactId int NOT NULL,&#xA;    NewOrganizationContactId int NULL,&#xA;    SupplierContactId int NOT NULL,&#xA;    NewSupplierContactId int NULL&#xA;);&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="createOrderContactsTempTableSql">
+      <DTS:VariableValue
+        DTS:DataType="8">CREATE TABLE ##OrderContacts
+(
+    OrderId int NOT NULL PRIMARY KEY,
+    OrganizationContactId int NOT NULL,
+    NewOrganizationContactId int NULL,
+    SupplierContactId int NOT NULL,
+    NewSupplierContactId int NULL
+);</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{DE51BB71-434F-461F-A7A1-E1B9DC765C1A}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;CREATE TABLE &quot; + @[User::organizationIDsTempTableName] + &quot;&#xA;(&#xA;    Id uniqueidentifier PRIMARY KEY&#xA;);&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="createOrganizationIDsTempTableSql">
+      <DTS:VariableValue
+        DTS:DataType="8">CREATE TABLE ##OrganizationIDs
+(
+    Id uniqueidentifier PRIMARY KEY
+);</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{10CFE469-11F3-43CF-87BC-3FE8CB25D7E1}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;CREATE TABLE &quot; + @[User::supplierAddressesTempTableName]  + &quot;&#xA;(&#xA;    SupplierId nvarchar(6) PRIMARY KEY,&#xA;    Line1 nvarchar(256) NOT NULL,&#xA;    Line2 nvarchar(256) NULL,&#xA;    Line3 nvarchar(256) NULL,&#xA;    Line4 nvarchar(256) NULL,&#xA;    Line5 nvarchar(256) NULL,&#xA;    Town nvarchar(256) NULL,&#xA;    County nvarchar(256) NULL,&#xA;    Postcode nvarchar(10) NOT NULL,&#xA;    Country nvarchar(256) NULL&#xA;);&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="createSupplierAddressesTempTableSql">
+      <DTS:VariableValue
+        DTS:DataType="8">CREATE TABLE ##SupplierAddresses
+(
+    SupplierId nvarchar(6) PRIMARY KEY,
+    Line1 nvarchar(256) NOT NULL,
+    Line2 nvarchar(256) NULL,
+    Line3 nvarchar(256) NULL,
+    Line4 nvarchar(256) NULL,
+    Line5 nvarchar(256) NULL,
+    Town nvarchar(256) NULL,
+    County nvarchar(256) NULL,
+    Postcode nvarchar(10) NOT NULL,
+    Country nvarchar(256) NULL
+);</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{B2F5C662-E164-4E95-8934-5AECDC1A8D3A}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;CREATE TABLE &quot; + @[User::suppliersTempTableName] + &quot;&#xA;(&#xA;    Id nvarchar(6) NOT NULL PRIMARY KEY,&#xA;    [Name] nvarchar(256) NOT NULL,&#xA;    AddressId int NULL&#xA;);&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="createSuppliersTempTableSql">
+      <DTS:VariableValue
+        DTS:DataType="8">CREATE TABLE ##Suppliers
+(
+    Id nvarchar(6) NOT NULL PRIMARY KEY,
+    [Name] nvarchar(256) NOT NULL,
+    AddressId int NULL
+);</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{F287614F-978E-490C-932E-0E7A13E0C689}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;SELECT OrganizationId&#xA;  FROM &quot; + @[User::addressesTempTableName] + &quot;;&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="getOrganizationIDsSql">
+      <DTS:VariableValue
+        DTS:DataType="8">SELECT OrganizationId
+  FROM ##OrganizationAddresses;</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{A171C9C8-5D4A-46EB-A538-C595D282AD3B}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;SELECT Id&#xA;  FROM &quot; + @[User::suppliersTempTableName] + &quot;;&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="getSupplierIDsSql">
+      <DTS:VariableValue
+        DTS:DataType="8">SELECT Id
+  FROM ##Suppliers;</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{11031D42-AAB5-4B0E-BC3E-DE2F85D12447}"
+      DTS:IncludeInDebugDump="6789"
+      DTS:Namespace="User"
+      DTS:ObjectName="identityValue">
+      <DTS:VariableValue
+        DTS:DataType="3">0</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{3B0CE0F9-B95F-449B-9CCA-5356E9F89B9A}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="orderContactsTempTableName">
+      <DTS:VariableValue
+        DTS:DataType="8">##OrderContacts</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{26B01849-D548-4A15-8D97-56010D487569}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;WITH AddressIds AS&#xA;(&#xA;    SELECT DISTINCT OrganisationId,&#xA;           MAX(OrganisationAddressId) OVER (PARTITION BY OrganisationId) AS AddressId&#xA;      FROM dbo.[Order]&#xA;     WHERE OrganisationId IN (SELECT Id FROM &quot; + @[User::organizationIDsTempTableName]  + &quot;)&#xA;)&#xA;SELECT i.OrganisationId, a.Line1, a.Line2, a.Line3, a.Line4, a.Line5, a.Town, a.County, a.Postcode, a.Country&#xA;  FROM AddressIds AS i&#xA;       INNER JOIN dbo.[Address] AS a ON a.AddressId = i.AddressId;&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="organizationAddressIDsCommand">
+      <DTS:VariableValue
+        DTS:DataType="8">WITH AddressIds AS
+(
+    SELECT DISTINCT OrganisationId,
+           MAX(OrganisationAddressId) OVER (PARTITION BY OrganisationId) AS AddressId
+      FROM dbo.[Order]
+     WHERE OrganisationId IN (SELECT Id FROM ##OrganizationIDs)
+)
+SELECT i.OrganisationId, a.Line1, a.Line2, a.Line3, a.Line4, a.Line5, a.Town, a.County, a.Postcode, a.Country
+  FROM AddressIds AS i
+       INNER JOIN dbo.[Address] AS a ON a.AddressId = i.AddressId;</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{5C8B629E-FC7B-4697-98FD-EB64EA49446A}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="organizationId">
+      <DTS:VariableValue
+        DTS:DataType="8"
+        xml:space="preserve"></DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{DE48EE52-6560-4D74-9C36-5E7CA7168F9F}"
+      DTS:IncludeInDebugDump="6789"
+      DTS:Namespace="User"
+      DTS:ObjectName="organizationIDs">
+      <DTS:VariableValue
+        DTS:DataSubType="ManagedSerializable"
+        DTS:DataType="13">
+        <SOAP-ENV:Envelope xmlns:clr="http://schemas.microsoft.com/soap/encoding/clr/1.0" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+          <SOAP-ENV:Body>
+            <xsd:anyType
+              id="ref-1"></xsd:anyType>
+          </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+      </DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{C057D4E5-8B71-4F83-A86A-CD05AFD510B7}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="organizationIDsTempTableName">
+      <DTS:VariableValue
+        DTS:DataType="8">##OrganizationIDs</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{8A51AD2D-49E6-4744-9970-8B1A074F925C}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;SELECT Id&#xA;FROM &quot; + @[User::contactsTempTableName] + &quot;;&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="selectContactIDsSql">
+      <DTS:VariableValue
+        DTS:DataType="8">SELECT Id
+FROM ##Contacts;</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{08009F35-CC7D-493D-B00A-1271513FBEEC}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="supplierAddressesTempTableName">
+      <DTS:VariableValue
+        DTS:DataType="8">##SupplierAddresses</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{221B084A-B3F3-444F-BFEE-431FCA1B0AFE}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="supplierId">
+      <DTS:VariableValue
+        DTS:DataType="8"
+        xml:space="preserve"></DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{E56CCCA4-6D37-477C-81E7-91AD8CD4EE64}"
+      DTS:IncludeInDebugDump="6789"
+      DTS:Namespace="User"
+      DTS:ObjectName="supplierIdentityValue">
+      <DTS:VariableValue
+        DTS:DataType="3">0</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{F7AF118C-5316-4728-8B31-F4E0E4E3D4C9}"
+      DTS:IncludeInDebugDump="6789"
+      DTS:Namespace="User"
+      DTS:ObjectName="supplierIDs">
+      <DTS:VariableValue
+        DTS:DataSubType="ManagedSerializable"
+        DTS:DataType="13">
+        <SOAP-ENV:Envelope xmlns:clr="http://schemas.microsoft.com/soap/encoding/clr/1.0" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+          <SOAP-ENV:Body>
+            <xsd:anyType
+              id="ref-1"></xsd:anyType>
+          </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+      </DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{0520D68E-CBBF-4930-BFB7-D40F68E9DFB8}"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="suppliersTempTableName">
+      <DTS:VariableValue
+        DTS:DataType="8">##Suppliers</DTS:VariableValue>
+    </DTS:Variable>
+    <DTS:Variable
+      DTS:CreationName=""
+      DTS:DTSID="{EA94CF83-65BA-4A9E-BF87-9E7536581711}"
+      DTS:EvaluateAsExpression="True"
+      DTS:Expression="&quot;UPDATE &quot; + @[User::suppliersTempTableName]   + &quot;&#xA;   SET AddressId = ?&#xA; WHERE Id = ?;&quot;"
+      DTS:IncludeInDebugDump="2345"
+      DTS:Namespace="User"
+      DTS:ObjectName="updateSupplierAddressDataSql">
+      <DTS:VariableValue
+        DTS:DataType="8">UPDATE ##Suppliers
+   SET AddressId = ?
+ WHERE Id = ?;</DTS:VariableValue>
+    </DTS:Variable>
+  </DTS:Variables>
+  <DTS:Executables>
+    <DTS:Executable
+      DTS:refId="Package\Add Price IDs"
+      DTS:CreationName="Microsoft.Pipeline"
+      DTS:Description="Data Flow Task"
+      DTS:DTSID="{97AA7268-ED5F-430A-9D7F-5613065CE34B}"
+      DTS:ExecutableType="Microsoft.Pipeline"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Add Price IDs"
+      DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <pipeline
+          version="1">
+          <components>
+            <component
+              refId="Package\Add Price IDs\Get Order Item Data"
+              componentClassID="Microsoft.OLEDBSource"
+              contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+              description="OLE DB Source"
+              name="Get Order Item Data"
+              usesDispositions="true"
+              version="7">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the name of the database object used to open a rowset."
+                  name="OpenRowset">[dbo].[OrderItem]</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the variable that contains the name of the database object used to open a rowset."
+                  name="OpenRowsetVariable"></property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT OrderId, CatalogueItemId, ProvisioningTypeId, CataloguePriceTypeId, PricingUnitName, TimeUnitId
+  FROM dbo.OrderItem
+ WHERE PriceId IS NULL;</property>
+                <property
+                  dataType="System.String"
+                  description="The variable that contains the SQL command to be executed."
+                  name="SqlCommandVariable"></property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Forces the use of the DefaultCodePage property value when describing character data."
+                  name="AlwaysUseDefaultCodePage">false</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the mode used to access the database."
+                  name="AccessMode"
+                  typeConverter="AccessMode">2</property>
+                <property
+                  dataType="System.String"
+                  description="The mappings between the parameters in the SQL command and variables."
+                  name="ParameterMapping"></property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Add Price IDs\Get Order Item Data.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <outputs>
+                <output
+                  refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output]"
+                  name="OLE DB Source Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[OrderId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[OrderId]"
+                      name="OrderId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                      length="14"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                      name="CatalogueItemId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[ProvisioningTypeId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[ProvisioningTypeId]"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[ProvisioningTypeId]"
+                      name="ProvisioningTypeId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[CataloguePriceTypeId]"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CataloguePriceTypeId]"
+                      name="CataloguePriceTypeId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[PricingUnitName]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitName]"
+                      length="20"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[PricingUnitName]"
+                      name="PricingUnitName"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[TimeUnitId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[TimeUnitId]"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[TimeUnitId]"
+                      name="TimeUnitId"
+                      truncationRowDisposition="FailComponent" />
+                  </outputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                      dataType="i4"
+                      name="OrderId" />
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      name="CatalogueItemId" />
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[ProvisioningTypeId]"
+                      dataType="i4"
+                      name="ProvisioningTypeId" />
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      name="CataloguePriceTypeId" />
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitName]"
+                      dataType="wstr"
+                      length="20"
+                      name="PricingUnitName" />
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].ExternalColumns[TimeUnitId]"
+                      dataType="i4"
+                      name="TimeUnitId" />
+                  </externalMetadataColumns>
+                </output>
+                <output
+                  refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output]"
+                  isErrorOut="true"
+                  name="OLE DB Source Error Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                      name="OrderId" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                      name="CatalogueItemId" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[ProvisioningTypeId]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[ProvisioningTypeId]"
+                      name="ProvisioningTypeId" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[CataloguePriceTypeId]"
+                      name="CataloguePriceTypeId" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[PricingUnitName]"
+                      dataType="wstr"
+                      length="20"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[PricingUnitName]"
+                      name="PricingUnitName" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[TimeUnitId]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[TimeUnitId]"
+                      name="TimeUnitId" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+            <component
+              refId="Package\Add Price IDs\Lookup Price ID"
+              componentClassID="Microsoft.Lookup"
+              contactInfo="Lookup;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;6"
+              description="Joins additional columns to the data flow by looking up values in a table. For example, join to the 'employee id' column the employees table to get 'hire date' and 'employee name'. We recommend this transformation when the lookup table can fit into memory."
+              name="Lookup Price ID"
+              usesDispositions="true"
+              version="6">
+              <properties>
+                <property
+                  dataType="System.String"
+                  description="Specifies the SQL statement that generates the lookup table."
+                  expressionType="Notify"
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT p.CataloguePriceId, p.CatalogueItemId, p.ProvisioningTypeId, p.CataloguePriceTypeId, p.TimeUnitId, u.[Name]
+  FROM dbo.CataloguePrice AS p
+       INNER JOIN dbo.PricingUnit AS u
+               ON u.PricingUnitId = p.PricingUnitId;</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies a SQL statement that uses parameters to generate the lookup table."
+                  expressionType="Notify"
+                  name="SqlCommandParam"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">select * from (SELECT p.CataloguePriceId, p.CatalogueItemId, p.ProvisioningTypeId, p.CataloguePriceTypeId, p.TimeUnitId, u.[Name]
+  FROM dbo.CataloguePrice AS p
+       INNER JOIN dbo.PricingUnit AS u
+               ON u.PricingUnitId = p.PricingUnitId;) [refTable]
+where [refTable].[CatalogueItemId] = ? and [refTable].[ProvisioningTypeId] = ? and [refTable].[CataloguePriceTypeId] = ? and [refTable].[Name] = ? and [refTable].[TimeUnitId] = ?</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the type of connection used to access the reference dataset."
+                  name="ConnectionType"
+                  typeConverter="LookupConnectionType">0</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the cache type of the lookup table."
+                  name="CacheType"
+                  typeConverter="CacheType">0</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies how the Lookup transformation handles rows without matching entries in the reference data set."
+                  name="NoMatchBehavior"
+                  typeConverter="LookupNoMatchBehavior">0</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the percentage of the cache that is allocated for rows with no matching entries in the reference dataset."
+                  name="NoMatchCachePercentage">0</property>
+                <property
+                  dataType="System.Int32"
+                  description="Maximum Memory Usage for Reference Cache on a 32 bit platform."
+                  name="MaxMemoryUsage">25</property>
+                <property
+                  dataType="System.Int64"
+                  description="Maximum Memory Usage for Reference Cache on a 64 bit platform."
+                  name="MaxMemoryUsage64">25</property>
+                <property
+                  dataType="System.String"
+                  description="Indicates whether to reference metadata in an XML format."
+                  name="ReferenceMetadataXml">&lt;referenceMetadata&gt;&lt;referenceColumns&gt;&lt;referenceColumn name="CataloguePriceId" dataType="DT_I4" length="0" precision="0" scale="0" codePage="0"/&gt;&lt;referenceColumn name="CatalogueItemId" dataType="DT_WSTR" length="14" precision="0" scale="0" codePage="0"/&gt;&lt;referenceColumn name="ProvisioningTypeId" dataType="DT_I4" length="0" precision="0" scale="0" codePage="0"/&gt;&lt;referenceColumn name="CataloguePriceTypeId" dataType="DT_I4" length="0" precision="0" scale="0" codePage="0"/&gt;&lt;referenceColumn name="TimeUnitId" dataType="DT_I4" length="0" precision="0" scale="0" codePage="0"/&gt;&lt;referenceColumn name="Name" dataType="DT_WSTR" length="20" precision="0" scale="0" codePage="0"/&gt;&lt;/referenceColumns&gt;&lt;/referenceMetadata&gt;</property>
+                <property
+                  containsID="true"
+                  dataType="System.String"
+                  description="Specifies the list of lineage identifiers that map to the parameters that the SQL statement in the SQLCommand property uses. Entries in the list are separated by semicolons."
+                  name="ParameterMap">#{Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CatalogueItemId]};#{Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[ProvisioningTypeId]};#{Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CataloguePriceTypeId]};#{Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[PricingUnitName]};#{Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[TimeUnitId]};</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Determines whether duplicate keys in the reference data should be treated as errors when full cache mode is used."
+                  name="TreatDuplicateKeysAsError">false</property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Add Price IDs\Lookup Price ID.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[BuyingCatalogue]"
+                  connectionManagerRefId="Package.ConnectionManagers[BuyingCatalogue]"
+                  description="Connection manager used to access lookup data."
+                  name="OleDbConnection" />
+              </connections>
+              <inputs>
+                <input
+                  refId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input]"
+                  name="Lookup Input">
+                  <inputColumns>
+                    <inputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input].Columns[CatalogueItemId]"
+                      cachedDataType="wstr"
+                      cachedLength="14"
+                      cachedName="CatalogueItemId"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CatalogueItemId]">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table that a column joins."
+                          name="JoinToReferenceColumn">CatalogueItemId</property>
+                        <property
+                          dataType="System.Null"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn" />
+                      </properties>
+                    </inputColumn>
+                    <inputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input].Columns[ProvisioningTypeId]"
+                      cachedDataType="i4"
+                      cachedName="ProvisioningTypeId"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[ProvisioningTypeId]">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table that a column joins."
+                          name="JoinToReferenceColumn">ProvisioningTypeId</property>
+                        <property
+                          dataType="System.Null"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn" />
+                      </properties>
+                    </inputColumn>
+                    <inputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input].Columns[CataloguePriceTypeId]"
+                      cachedDataType="i4"
+                      cachedName="CataloguePriceTypeId"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[CataloguePriceTypeId]">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table that a column joins."
+                          name="JoinToReferenceColumn">CataloguePriceTypeId</property>
+                        <property
+                          dataType="System.Null"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn" />
+                      </properties>
+                    </inputColumn>
+                    <inputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input].Columns[TimeUnitId]"
+                      cachedDataType="i4"
+                      cachedName="TimeUnitId"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[TimeUnitId]">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table that a column joins."
+                          name="JoinToReferenceColumn">TimeUnitId</property>
+                        <property
+                          dataType="System.Null"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn" />
+                      </properties>
+                    </inputColumn>
+                    <inputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input].Columns[PricingUnitName]"
+                      cachedDataType="wstr"
+                      cachedLength="20"
+                      cachedName="PricingUnitName"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[PricingUnitName]">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table that a column joins."
+                          name="JoinToReferenceColumn">Name</property>
+                        <property
+                          dataType="System.Null"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn" />
+                      </properties>
+                    </inputColumn>
+                  </inputColumns>
+                  <externalMetadataColumns />
+                </input>
+              </inputs>
+              <outputs>
+                <output
+                  refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output]"
+                  errorOrTruncationOperation="Lookup"
+                  errorRowDisposition="IgnoreFailure"
+                  exclusionGroup="1"
+                  name="Lookup Match Output"
+                  synchronousInputId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input]">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CatalogueItemId]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Copy Column"
+                      length="14"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CatalogueItemId]"
+                      name="CatalogueItemId"
+                      truncationRowDisposition="FailComponent">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn">CatalogueItemId</property>
+                      </properties>
+                    </outputColumn>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CataloguePriceId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Copy Column"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CataloguePriceId]"
+                      name="CataloguePriceId"
+                      truncationRowDisposition="FailComponent">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn">CataloguePriceId</property>
+                      </properties>
+                    </outputColumn>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[ProvisioningTypeId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Copy Column"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[ProvisioningTypeId]"
+                      name="ProvisioningTypeId"
+                      truncationRowDisposition="FailComponent">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn">ProvisioningTypeId</property>
+                      </properties>
+                    </outputColumn>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Copy Column"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CataloguePriceTypeId]"
+                      name="CataloguePriceTypeId"
+                      truncationRowDisposition="FailComponent">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn">CataloguePriceTypeId</property>
+                      </properties>
+                    </outputColumn>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[TimeUnitId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Copy Column"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[TimeUnitId]"
+                      name="TimeUnitId"
+                      truncationRowDisposition="FailComponent">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn">TimeUnitId</property>
+                      </properties>
+                    </outputColumn>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[Name]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Copy Column"
+                      length="20"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[Name]"
+                      name="Name"
+                      truncationRowDisposition="FailComponent">
+                      <properties>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the column in the reference table from which a column is copied."
+                          name="CopyFromReferenceColumn">Name</property>
+                      </properties>
+                    </outputColumn>
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+                <output
+                  refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup No Match Output]"
+                  description="The Lookup output that handles rows with no matching entries in the reference dataset. Use this output when the NoMatchBehavior property is set to &quot;Send rows with no matching entries to the no match output.&quot;"
+                  exclusionGroup="1"
+                  name="Lookup No Match Output"
+                  synchronousInputId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input]">
+                  <externalMetadataColumns />
+                </output>
+                <output
+                  refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Error Output]"
+                  exclusionGroup="1"
+                  isErrorOut="true"
+                  name="Lookup Error Output"
+                  synchronousInputId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input]">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+            <component
+              refId="Package\Add Price IDs\Set Price ID"
+              componentClassID="Microsoft.OLEDBCommand"
+              contactInfo="OLE DB Command;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;2"
+              description="Runs an SQL statement for each row in a data flow. For example, call a 'new employee setup' stored procedure for each row in the 'new employees' table. Note: running an SQL statement for each row of a large data flow may take a long time."
+              name="Set Price ID"
+              usesDispositions="true"
+              version="2">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  expressionType="Notify"
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">UPDATE dbo.OrderItem
+   SET PriceId = ?
+ WHERE OrderId = ?
+   AND CatalogueItemId = ?
+   AND CataloguePriceTypeId = ?
+   AND ProvisioningTypeId = ?
+   AND TimeUnitId = ?
+   AND PricingUnitName = ?;
+</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Add Price IDs\Set Price ID.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <inputs>
+                <input
+                  refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input]"
+                  errorOrTruncationOperation="Command Execution"
+                  errorRowDisposition="FailComponent"
+                  hasSideEffects="true"
+                  name="OLE DB Command Input">
+                  <inputColumns>
+                    <inputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].Columns[CataloguePriceId]"
+                      cachedDataType="i4"
+                      cachedName="CataloguePriceId"
+                      externalMetadataColumnId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_0]"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CataloguePriceId]" />
+                    <inputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].Columns[OrderId]"
+                      cachedDataType="i4"
+                      cachedName="OrderId"
+                      externalMetadataColumnId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_1]"
+                      lineageId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output].Columns[OrderId]" />
+                    <inputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].Columns[CatalogueItemId]"
+                      cachedDataType="wstr"
+                      cachedLength="14"
+                      cachedName="CatalogueItemId"
+                      externalMetadataColumnId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_2]"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CatalogueItemId]" />
+                    <inputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].Columns[CataloguePriceTypeId]"
+                      cachedDataType="i4"
+                      cachedName="CataloguePriceTypeId"
+                      externalMetadataColumnId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_3]"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[CataloguePriceTypeId]" />
+                    <inputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].Columns[ProvisioningTypeId]"
+                      cachedDataType="i4"
+                      cachedName="ProvisioningTypeId"
+                      externalMetadataColumnId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_4]"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[ProvisioningTypeId]" />
+                    <inputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].Columns[TimeUnitId]"
+                      cachedDataType="i4"
+                      cachedName="TimeUnitId"
+                      externalMetadataColumnId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_5]"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[TimeUnitId]" />
+                    <inputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].Columns[Name]"
+                      cachedDataType="wstr"
+                      cachedLength="20"
+                      cachedName="Name"
+                      externalMetadataColumnId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_6]"
+                      lineageId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output].Columns[Name]" />
+                  </inputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_0]"
+                      dataType="i4"
+                      name="Param_0">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="Parameter information.  Matches OLE DB's DBPARAMFLAGSENUM values."
+                          name="DBParamInfoFlags">81</property>
+                      </properties>
+                    </externalMetadataColumn>
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_1]"
+                      dataType="i4"
+                      name="Param_1">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="Parameter information.  Matches OLE DB's DBPARAMFLAGSENUM values."
+                          name="DBParamInfoFlags">81</property>
+                      </properties>
+                    </externalMetadataColumn>
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_2]"
+                      dataType="wstr"
+                      length="14"
+                      name="Param_2">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="Parameter information.  Matches OLE DB's DBPARAMFLAGSENUM values."
+                          name="DBParamInfoFlags">65</property>
+                      </properties>
+                    </externalMetadataColumn>
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_3]"
+                      dataType="i4"
+                      name="Param_3">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="Parameter information.  Matches OLE DB's DBPARAMFLAGSENUM values."
+                          name="DBParamInfoFlags">81</property>
+                      </properties>
+                    </externalMetadataColumn>
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_4]"
+                      dataType="i4"
+                      name="Param_4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="Parameter information.  Matches OLE DB's DBPARAMFLAGSENUM values."
+                          name="DBParamInfoFlags">81</property>
+                      </properties>
+                    </externalMetadataColumn>
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_5]"
+                      dataType="i4"
+                      name="Param_5">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="Parameter information.  Matches OLE DB's DBPARAMFLAGSENUM values."
+                          name="DBParamInfoFlags">65</property>
+                      </properties>
+                    </externalMetadataColumn>
+                    <externalMetadataColumn
+                      refId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input].ExternalColumns[Param_6]"
+                      dataType="wstr"
+                      length="20"
+                      name="Param_6">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="Parameter information.  Matches OLE DB's DBPARAMFLAGSENUM values."
+                          name="DBParamInfoFlags">65</property>
+                      </properties>
+                    </externalMetadataColumn>
+                  </externalMetadataColumns>
+                </input>
+              </inputs>
+              <outputs>
+                <output
+                  refId="Package\Add Price IDs\Set Price ID.Outputs[OLE DB Command Output]"
+                  exclusionGroup="1"
+                  name="OLE DB Command Output"
+                  synchronousInputId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input]">
+                  <externalMetadataColumns />
+                </output>
+                <output
+                  refId="Package\Add Price IDs\Set Price ID.Outputs[OLE DB Command Error Output]"
+                  exclusionGroup="1"
+                  isErrorOut="true"
+                  name="OLE DB Command Error Output"
+                  synchronousInputId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input]">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Outputs[OLE DB Command Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Set Price ID.Outputs[OLE DB Command Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Add Price IDs\Set Price ID.Outputs[OLE DB Command Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Add Price IDs\Set Price ID.Outputs[OLE DB Command Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+          </components>
+          <paths>
+            <path
+              refId="Package\Add Price IDs.Paths[Lookup Match Output]"
+              endId="Package\Add Price IDs\Set Price ID.Inputs[OLE DB Command Input]"
+              name="Lookup Match Output"
+              startId="Package\Add Price IDs\Lookup Price ID.Outputs[Lookup Match Output]" />
+            <path
+              refId="Package\Add Price IDs.Paths[OLE DB Source Output]"
+              endId="Package\Add Price IDs\Lookup Price ID.Inputs[Lookup Input]"
+              name="OLE DB Source Output"
+              startId="Package\Add Price IDs\Get Order Item Data.Outputs[OLE DB Source Output]" />
+          </paths>
+        </pipeline>
+      </DTS:ObjectData>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Delete Redundant Default Delivery Dates"
+      DTS:CreationName="Microsoft.ExecuteSQLTask"
+      DTS:Description="Execute SQL Task"
+      DTS:DTSID="{1C129DAD-D15B-4376-A771-5E5AF3BA7B6F}"
+      DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Delete Redundant Default Delivery Dates"
+      DTS:ThreadHint="0">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <SQLTask:SqlTaskData
+          SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+          SQLTask:SqlStatementSource="DELETE FROM dbo.DefaultDeliveryDate&#xA;       FROM dbo.DefaultDeliveryDate AS d&#xA;            INNER JOIN dbo.OrderItem AS o&#xA;                    ON o.OrderId = d.OrderId&#xA;                   AND o.CatalogueItemId = d.CatalogueItemId;&#xA;&#xA;DELETE FROM dbo.DefaultDeliveryDate&#xA;       FROM dbo.DefaultDeliveryDate AS d&#xA;            INNER JOIN dbo.[Order] AS o&#xA;                    ON o.Id = d.OrderId&#xA;      WHERE O.Completed IS NOT NULL;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+      </DTS:ObjectData>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Make Price ID Non-nullable"
+      DTS:CreationName="Microsoft.ExecuteSQLTask"
+      DTS:Description="Execute SQL Task"
+      DTS:DTSID="{502237C5-FBEE-4791-A8EF-689A569015E7}"
+      DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Make Price ID Non-nullable"
+      DTS:ThreadHint="0">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <SQLTask:SqlTaskData
+          SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+          SQLTask:SqlStatementSource="IF NOT EXISTS (SELECT * FROM dbo.OrderItem WHERE PriceId IS NULL)&#xA;BEGIN&#xA;    ALTER TABLE dbo.OrderItem&#xA;    ALTER COLUMN PriceId int NOT NULL;&#xA;END;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+      </DTS:ObjectData>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Migrate Contact Data"
+      DTS:CreationName="STOCK:SEQUENCE"
+      DTS:Description="Sequence Container"
+      DTS:DTSID="{DBFDAAAB-DB53-4DAB-B77F-9435B03397C8}"
+      DTS:ExecutableType="STOCK:SEQUENCE"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Migrate Contact Data">
+      <DTS:Variables />
+      <DTS:Executables>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Contact Data\Copy Contact Data"
+          DTS:CreationName="STOCK:SEQUENCE"
+          DTS:Description="Sequence Container"
+          DTS:DTSID="{F2384B4E-CE86-4ADB-8358-2D11E888BFA7}"
+          DTS:ExecutableType="STOCK:SEQUENCE"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Copy Contact Data">
+          <DTS:Variables />
+          <DTS:Executables>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table"
+              DTS:CreationName="Microsoft.Pipeline"
+              DTS:DelayValidation="True"
+              DTS:Description="Data Flow Task"
+              DTS:DTSID="{C0B6FDF4-3464-446D-AD5D-99FCD1206A5B}"
+              DTS:ExecutableType="Microsoft.Pipeline"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Copy Contacts to Temp Table"
+              DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <pipeline
+                  version="1">
+                  <components>
+                    <component
+                      refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts"
+                      componentClassID="Microsoft.OLEDBSource"
+                      contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                      description="OLE DB Source"
+                      name="Get Contacts"
+                      usesDispositions="true"
+                      version="7">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable"></property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">WITH ContactIDs AS
+(
+    SELECT OrganisationContactId AS ContactId
+    FROM dbo.[Order]
+    WHERE OrganisationContactId IS NOT NULL
+    UNION
+    SELECT SupplierContactId AS ContactId
+    FROM dbo.[Order]
+    WHERE SupplierContactId IS NOT NULL
+)
+    SELECT ContactId, FirstName, LastName, Email, Phone
+      FROM dbo.Contact
+     WHERE ContactId IN (SELECT ContactId FROM ContactIDs);</property>
+                        <property
+                          dataType="System.String"
+                          description="The variable that contains the SQL command to be executed."
+                          name="SqlCommandVariable"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">2</property>
+                        <property
+                          dataType="System.String"
+                          description="The mappings between the parameters in the SQL command and variables."
+                          name="ParameterMapping"></property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output]"
+                          name="OLE DB Source Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[ContactId]"
+                              dataType="i4"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[ContactId]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[ContactId]"
+                              name="ContactId"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[FirstName]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[FirstName]"
+                              length="100"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[FirstName]"
+                              name="FirstName"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[LastName]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[LastName]"
+                              length="100"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[LastName]"
+                              name="LastName"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[Email]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[Email]"
+                              length="256"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[Email]"
+                              name="Email"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[Phone]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[Phone]"
+                              length="35"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[Phone]"
+                              name="Phone"
+                              truncationRowDisposition="FailComponent" />
+                          </outputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[ContactId]"
+                              dataType="i4"
+                              name="ContactId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[FirstName]"
+                              dataType="wstr"
+                              length="100"
+                              name="FirstName" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[LastName]"
+                              dataType="wstr"
+                              length="100"
+                              name="LastName" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[Email]"
+                              dataType="wstr"
+                              length="256"
+                              name="Email" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].ExternalColumns[Phone]"
+                              dataType="wstr"
+                              length="35"
+                              name="Phone" />
+                          </externalMetadataColumns>
+                        </output>
+                        <output
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output]"
+                          isErrorOut="true"
+                          name="OLE DB Source Error Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[ContactId]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[ContactId]"
+                              name="ContactId" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[FirstName]"
+                              dataType="wstr"
+                              length="100"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[FirstName]"
+                              name="FirstName" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[LastName]"
+                              dataType="wstr"
+                              length="100"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[LastName]"
+                              name="LastName" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[Email]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[Email]"
+                              name="Email" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[Phone]"
+                              dataType="wstr"
+                              length="35"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[Phone]"
+                              name="Phone" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table"
+                      componentClassID="Microsoft.OLEDBDestination"
+                      contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                      description="OLE DB Destination"
+                      name="Insert Into Contacts Temp Table"
+                      usesDispositions="true"
+                      version="4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable">User::contactsTempTableName</property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">4</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepIdentity">false</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepNulls">false</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                          name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                          name="FastLoadMaxInsertCommitSize">2147483647</property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input]"
+                          errorOrTruncationOperation="Insert"
+                          errorRowDisposition="FailComponent"
+                          hasSideEffects="true"
+                          name="OLE DB Destination Input">
+                          <inputColumns>
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[FirstName]"
+                              cachedDataType="wstr"
+                              cachedLength="100"
+                              cachedName="FirstName"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[FirstName]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[FirstName]" />
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[LastName]"
+                              cachedDataType="wstr"
+                              cachedLength="100"
+                              cachedName="LastName"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[LastName]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[LastName]" />
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[Email]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Email"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Email]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[Email]" />
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[Phone]"
+                              cachedDataType="wstr"
+                              cachedLength="35"
+                              cachedName="Phone"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Phone]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[Phone]" />
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[ContactId]"
+                              cachedDataType="i4"
+                              cachedName="ContactId"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output].Columns[ContactId]" />
+                          </inputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              dataType="i4"
+                              name="Id" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[FirstName]"
+                              dataType="wstr"
+                              length="100"
+                              name="FirstName" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[LastName]"
+                              dataType="wstr"
+                              length="100"
+                              name="LastName" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Email]"
+                              dataType="wstr"
+                              length="256"
+                              name="Email" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Phone]"
+                              dataType="wstr"
+                              length="35"
+                              name="Phone" />
+                          </externalMetadataColumns>
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Outputs[OLE DB Destination Error Output]"
+                          exclusionGroup="1"
+                          isErrorOut="true"
+                          name="OLE DB Destination Error Output"
+                          synchronousInputId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input]">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                  </components>
+                  <paths>
+                    <path
+                      refId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table.Paths[OLE DB Source Output]"
+                      endId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table.Inputs[OLE DB Destination Input]"
+                      name="OLE DB Source Output"
+                      startId="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts.Outputs[OLE DB Source Output]" />
+                  </paths>
+                </pipeline>
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table"
+              DTS:CreationName="Microsoft.Pipeline"
+              DTS:DelayValidation="True"
+              DTS:Description="Data Flow Task"
+              DTS:DTSID="{7880A05F-88BD-4DAA-AB1C-963F00FE8DE8}"
+              DTS:ExecutableType="Microsoft.Pipeline"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Copy Order Contacts to Temp Table"
+              DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <pipeline
+                  version="1">
+                  <components>
+                    <component
+                      refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts"
+                      componentClassID="Microsoft.OLEDBSource"
+                      contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                      description="OLE DB Source"
+                      name="Get Order Contacts"
+                      usesDispositions="true"
+                      version="7">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable"></property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT CAST(SUBSTRING(OrderId, 3, 5) AS int) AS OrderId, OrganisationContactId, SupplierContactId
+FROM dbo.[Order]
+WHERE NOT (OrganisationContactId IS NULL AND SupplierContactId IS NULL);</property>
+                        <property
+                          dataType="System.String"
+                          description="The variable that contains the SQL command to be executed."
+                          name="SqlCommandVariable"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">2</property>
+                        <property
+                          dataType="System.String"
+                          description="The mappings between the parameters in the SQL command and variables."
+                          name="ParameterMapping"></property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output]"
+                          name="OLE DB Source Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[OrderId]"
+                              dataType="i4"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[OrderId]"
+                              name="OrderId"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[OrganisationContactId]"
+                              dataType="i4"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].ExternalColumns[OrganisationContactId]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[OrganisationContactId]"
+                              name="OrganisationContactId"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[SupplierContactId]"
+                              dataType="i4"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].ExternalColumns[SupplierContactId]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[SupplierContactId]"
+                              name="SupplierContactId"
+                              truncationRowDisposition="FailComponent" />
+                          </outputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                              dataType="i4"
+                              name="OrderId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].ExternalColumns[OrganisationContactId]"
+                              dataType="i4"
+                              name="OrganisationContactId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].ExternalColumns[SupplierContactId]"
+                              dataType="i4"
+                              name="SupplierContactId" />
+                          </externalMetadataColumns>
+                        </output>
+                        <output
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output]"
+                          isErrorOut="true"
+                          name="OLE DB Source Error Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                              name="OrderId" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[OrganisationContactId]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[OrganisationContactId]"
+                              name="OrganisationContactId" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[SupplierContactId]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[SupplierContactId]"
+                              name="SupplierContactId" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table"
+                      componentClassID="Microsoft.OLEDBDestination"
+                      contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                      description="OLE DB Destination"
+                      name="Insert Into Order Contacts Temp Table"
+                      usesDispositions="true"
+                      version="4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable">User::orderContactsTempTableName</property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">4</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepIdentity">false</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepNulls">false</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                          name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                          name="FastLoadMaxInsertCommitSize">2147483647</property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input]"
+                          errorOrTruncationOperation="Insert"
+                          errorRowDisposition="FailComponent"
+                          hasSideEffects="true"
+                          name="OLE DB Destination Input">
+                          <inputColumns>
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[OrderId]"
+                              cachedDataType="i4"
+                              cachedName="OrderId"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[OrderId]" />
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[SupplierContactId]"
+                              cachedDataType="i4"
+                              cachedName="SupplierContactId"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[SupplierContactId]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[SupplierContactId]" />
+                            <inputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].Columns[OrganisationContactId]"
+                              cachedDataType="i4"
+                              cachedName="OrganisationContactId"
+                              externalMetadataColumnId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[OrganizationContactId]"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output].Columns[OrganisationContactId]" />
+                          </inputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                              dataType="i4"
+                              name="OrderId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[OrganizationContactId]"
+                              dataType="i4"
+                              name="OrganizationContactId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[SupplierContactId]"
+                              dataType="i4"
+                              name="SupplierContactId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[NewOrganizationContactId]"
+                              dataType="i4"
+                              name="NewOrganizationContactId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[NewSupplierContactId]"
+                              dataType="i4"
+                              name="NewSupplierContactId" />
+                          </externalMetadataColumns>
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Outputs[OLE DB Destination Error Output]"
+                          exclusionGroup="1"
+                          isErrorOut="true"
+                          name="OLE DB Destination Error Output"
+                          synchronousInputId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input]">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                  </components>
+                  <paths>
+                    <path
+                      refId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table.Paths[OLE DB Source Output]"
+                      endId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table.Inputs[OLE DB Destination Input]"
+                      name="OLE DB Source Output"
+                      startId="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts.Outputs[OLE DB Source Output]" />
+                  </paths>
+                </pipeline>
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data\Create Contacts Temp Table"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{ED002C13-6EB7-4578-835A-6F9C1B123DCA}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Create Contacts Temp Table"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::createContactsTempTableSql" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data\Create OrderContacts Temp Table"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{B8C660C3-4CAB-429D-AACE-017930961FED}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Create OrderContacts Temp Table"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::createOrderContactsTempTableSql" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data\Load Contact IDs Into Recordset"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{7D73D8CC-E890-4F08-96E5-30B2AA9AB3FA}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Load Contact IDs Into Recordset"
+              DTS:ThreadHint="1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::selectContactIDsSql"
+                  SQLTask:ResultType="ResultSetType_Rowset" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+                  <SQLTask:ResultBinding
+                    SQLTask:ResultName="0"
+                    SQLTask:DtsVariableName="User::contactIDs" />
+                </SQLTask:SqlTaskData>
+              </DTS:ObjectData>
+            </DTS:Executable>
+          </DTS:Executables>
+          <DTS:PrecedenceConstraints>
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint]"
+              DTS:CreationName=""
+              DTS:DTSID="{5334A1A7-BA2D-446E-B30B-A6702DD92917}"
+              DTS:From="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint"
+              DTS:To="Package\Migrate Contact Data\Copy Contact Data\Load Contact IDs Into Recordset" />
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint 1]"
+              DTS:CreationName=""
+              DTS:DTSID="{81487618-4E5A-4B54-A75A-2D24AF114989}"
+              DTS:From="Package\Migrate Contact Data\Copy Contact Data\Create Contacts Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint 1"
+              DTS:To="Package\Migrate Contact Data\Copy Contact Data\Create OrderContacts Temp Table" />
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint 2]"
+              DTS:CreationName=""
+              DTS:DTSID="{C27EBC41-C5D9-4B56-BE8F-E616ACE45C46}"
+              DTS:From="Package\Migrate Contact Data\Copy Contact Data\Create OrderContacts Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint 2"
+              DTS:To="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table" />
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint 4]"
+              DTS:CreationName=""
+              DTS:DTSID="{53C43B8D-5010-4834-BB41-C3C6C42DFBFC}"
+              DTS:From="Package\Migrate Contact Data\Copy Contact Data\Create Contacts Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint 4"
+              DTS:To="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table" />
+          </DTS:PrecedenceConstraints>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Contact Data\Recreate Contacts"
+          DTS:CreationName="STOCK:FOREACHLOOP"
+          DTS:Description="Foreach Loop Container"
+          DTS:DTSID="{6D6C2CA4-8A19-4328-87F9-9538EF7041D2}"
+          DTS:ExecutableType="STOCK:FOREACHLOOP"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Recreate Contacts">
+          <DTS:ForEachEnumerator
+            DTS:CreationName="Microsoft.ForEachADOEnumerator"
+            DTS:DTSID="{FCFE6FE5-D9E1-46DF-BDA5-0A4D53C8681A}"
+            DTS:ObjectName="{FCFE6FE5-D9E1-46DF-BDA5-0A4D53C8681A}">
+            <DTS:ObjectData>
+              <FEEADO
+                EnumType="EnumerateRowsInFirstTable"
+                VarName="User::contactIDs" />
+            </DTS:ObjectData>
+          </DTS:ForEachEnumerator>
+          <DTS:Variables />
+          <DTS:Executables>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Contact Data\Recreate Contacts\Add Contact Data"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{30F56B79-772D-4070-AC65-EC3322EEE270}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Add Contact Data"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::addContactDataSql"
+                  SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+                  <SQLTask:ResultBinding
+                    SQLTask:ResultName="0"
+                    SQLTask:DtsVariableName="User::contactIdentityValue" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="0"
+                    SQLTask:DtsVariableName="User::contactId"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="3"
+                    SQLTask:ParameterSize="-1" />
+                </SQLTask:SqlTaskData>
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Contact Data\Recreate Contacts\Update Order Contacts Temp Table"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{5DF8D192-0C38-4BE8-9774-909608E0C130}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Update Order Contacts Temp Table"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStatementSource="UPDATE ##OrderContacts&#xA;   SET NewOrganizationContactId = ?&#xA; WHERE OrganizationContactId = ?;&#xA;&#xA;UPDATE ##OrderContacts&#xA;   SET NewSupplierContactId = ?&#xA; WHERE SupplierContactId = ?;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="0"
+                    SQLTask:DtsVariableName="User::contactIdentityValue"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="3"
+                    SQLTask:ParameterSize="-1" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="1"
+                    SQLTask:DtsVariableName="User::contactId"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="3"
+                    SQLTask:ParameterSize="-1" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="2"
+                    SQLTask:DtsVariableName="User::contactIdentityValue"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="3"
+                    SQLTask:ParameterSize="-1" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="3"
+                    SQLTask:DtsVariableName="User::contactId"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="3"
+                    SQLTask:ParameterSize="-1" />
+                </SQLTask:SqlTaskData>
+              </DTS:ObjectData>
+            </DTS:Executable>
+          </DTS:Executables>
+          <DTS:PrecedenceConstraints>
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Contact Data\Recreate Contacts.PrecedenceConstraints[Constraint]"
+              DTS:CreationName=""
+              DTS:DTSID="{45B555C8-095F-4113-AFEE-DA4DBDCFAF24}"
+              DTS:From="Package\Migrate Contact Data\Recreate Contacts\Add Contact Data"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint"
+              DTS:To="Package\Migrate Contact Data\Recreate Contacts\Update Order Contacts Temp Table" />
+          </DTS:PrecedenceConstraints>
+          <DTS:ForEachVariableMappings>
+            <DTS:ForEachVariableMapping
+              DTS:CreationName=""
+              DTS:DTSID="{39218D76-0E7B-49FE-AB70-6DA34AF34818}"
+              DTS:ObjectName="{39218D76-0E7B-49FE-AB70-6DA34AF34818}"
+              DTS:ValueIndex="0"
+              DTS:VariableName="User::contactId" />
+          </DTS:ForEachVariableMappings>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Contact Data\Update Orders Table with Contacts"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{B041F920-BCFF-4258-BA87-04FDD2ACB59A}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Update Orders Table with Contacts"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+              SQLTask:SqlStatementSource=" UPDATE o&#xA;    SET o.OrderingPartyContactId = c.NewOrganizationContactId,&#xA;        o.SupplierContactId = c.NewOrganizationContactId&#xA;   FROM dbo.[Order] AS o&#xA;        INNER JOIN ##OrderContacts AS c ON c.OrderId = o.Id;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+      </DTS:Executables>
+      <DTS:PrecedenceConstraints>
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Migrate Contact Data.PrecedenceConstraints[Constraint 2]"
+          DTS:CreationName=""
+          DTS:DTSID="{93FFCE3B-3BA5-4DBD-A7AF-5D9C982DCFB1}"
+          DTS:From="Package\Migrate Contact Data\Copy Contact Data"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 2"
+          DTS:To="Package\Migrate Contact Data\Recreate Contacts" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Migrate Contact Data.PrecedenceConstraints[Constraint 4]"
+          DTS:CreationName=""
+          DTS:DTSID="{C316E24E-8368-48EE-A063-E1B363D4D0BE}"
+          DTS:From="Package\Migrate Contact Data\Recreate Contacts"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 4"
+          DTS:To="Package\Migrate Contact Data\Update Orders Table with Contacts" />
+      </DTS:PrecedenceConstraints>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Migrate Order Item Recipients"
+      DTS:CreationName="Microsoft.Pipeline"
+      DTS:Description="Data Flow Task"
+      DTS:DTSID="{000E4846-F270-4254-9A66-575FC22328B8}"
+      DTS:ExecutableType="Microsoft.Pipeline"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Migrate Order Item Recipients"
+      DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <pipeline
+          version="1">
+          <components>
+            <component
+              refId="Package\Migrate Order Item Recipients\Get Recipients"
+              componentClassID="Microsoft.OLEDBSource"
+              contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+              description="OLE DB Source"
+              name="Get Recipients"
+              usesDispositions="true"
+              version="7">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the name of the database object used to open a rowset."
+                  name="OpenRowset"></property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the variable that contains the name of the database object used to open a rowset."
+                  name="OpenRowsetVariable"></property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">WITH Items AS
+(
+    SELECT CAST(SUBSTRING(OrderId, 3, 5) AS int) AS OrderId,
+           ROW_NUMBER() OVER (PARTITION BY OrderId, CatalogueItemId ORDER BY Created DESC) AS Latest,
+           CatalogueItemId, OdsCode, Quantity, DeliveryDate
+      FROM dbo.OrderItem
+)
+  SELECT OrderId, CatalogueItemId, OdsCode, Quantity, DeliveryDate
+    FROM Items
+   WHERE Latest = 1;</property>
+                <property
+                  dataType="System.String"
+                  description="The variable that contains the SQL command to be executed."
+                  name="SqlCommandVariable"></property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Forces the use of the DefaultCodePage property value when describing character data."
+                  name="AlwaysUseDefaultCodePage">false</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the mode used to access the database."
+                  name="AccessMode"
+                  typeConverter="AccessMode">2</property>
+                <property
+                  dataType="System.String"
+                  description="The mappings between the parameters in the SQL command and variables."
+                  name="ParameterMapping"></property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Migrate Order Item Recipients\Get Recipients.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <outputs>
+                <output
+                  refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output]"
+                  name="OLE DB Source Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[OrderId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[OrderId]"
+                      name="OrderId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                      length="14"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                      name="CatalogueItemId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[OdsCode]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[OdsCode]"
+                      length="8"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[OdsCode]"
+                      name="OdsCode"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[Quantity]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[Quantity]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[Quantity]"
+                      name="Quantity"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[DeliveryDate]"
+                      dataType="dbDate"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[DeliveryDate]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[DeliveryDate]"
+                      name="DeliveryDate"
+                      truncationRowDisposition="FailComponent" />
+                  </outputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                      dataType="i4"
+                      name="OrderId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      name="CatalogueItemId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[OdsCode]"
+                      dataType="wstr"
+                      length="8"
+                      name="OdsCode" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[Quantity]"
+                      dataType="i4"
+                      name="Quantity" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].ExternalColumns[DeliveryDate]"
+                      dataType="dbDate"
+                      name="DeliveryDate" />
+                  </externalMetadataColumns>
+                </output>
+                <output
+                  refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output]"
+                  isErrorOut="true"
+                  name="OLE DB Source Error Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                      name="OrderId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                      name="CatalogueItemId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[OdsCode]"
+                      dataType="wstr"
+                      length="8"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[OdsCode]"
+                      name="OdsCode" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[Quantity]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[Quantity]"
+                      name="Quantity" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[DeliveryDate]"
+                      dataType="dbDate"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[DeliveryDate]"
+                      name="DeliveryDate" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+            <component
+              refId="Package\Migrate Order Item Recipients\Insert Recipients"
+              componentClassID="Microsoft.OLEDBDestination"
+              contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+              description="OLE DB Destination"
+              name="Insert Recipients"
+              usesDispositions="true"
+              version="4">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the name of the database object used to open a rowset."
+                  name="OpenRowset">[dbo].[OrderItemRecipients]</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the variable that contains the name of the database object used to open a rowset."
+                  name="OpenRowsetVariable"></property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Forces the use of the DefaultCodePage property value when describing character data."
+                  name="AlwaysUseDefaultCodePage">false</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the mode used to access the database."
+                  name="AccessMode"
+                  typeConverter="AccessMode">3</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                  name="FastLoadKeepIdentity">false</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                  name="FastLoadKeepNulls">false</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                  name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                  name="FastLoadMaxInsertCommitSize">2147483647</property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Migrate Order Item Recipients\Insert Recipients.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <inputs>
+                <input
+                  refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input]"
+                  errorOrTruncationOperation="Insert"
+                  errorRowDisposition="FailComponent"
+                  hasSideEffects="true"
+                  name="OLE DB Destination Input">
+                  <inputColumns>
+                    <inputColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].Columns[OrderId]"
+                      cachedDataType="i4"
+                      cachedName="OrderId"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[OrderId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].Columns[CatalogueItemId]"
+                      cachedDataType="wstr"
+                      cachedLength="14"
+                      cachedName="CatalogueItemId"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemId]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[CatalogueItemId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].Columns[OdsCode]"
+                      cachedDataType="wstr"
+                      cachedLength="8"
+                      cachedName="OdsCode"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[OdsCode]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[OdsCode]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].Columns[Quantity]"
+                      cachedDataType="i4"
+                      cachedName="Quantity"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[Quantity]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[Quantity]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].Columns[DeliveryDate]"
+                      cachedDataType="dbDate"
+                      cachedName="DeliveryDate"
+                      externalMetadataColumnId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[DeliveryDate]"
+                      lineageId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output].Columns[DeliveryDate]" />
+                  </inputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                      dataType="i4"
+                      name="OrderId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      name="CatalogueItemId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[OdsCode]"
+                      dataType="wstr"
+                      length="8"
+                      name="OdsCode" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[Quantity]"
+                      dataType="i4"
+                      name="Quantity" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input].ExternalColumns[DeliveryDate]"
+                      dataType="dbDate"
+                      name="DeliveryDate" />
+                  </externalMetadataColumns>
+                </input>
+              </inputs>
+              <outputs>
+                <output
+                  refId="Package\Migrate Order Item Recipients\Insert Recipients.Outputs[OLE DB Destination Error Output]"
+                  exclusionGroup="1"
+                  isErrorOut="true"
+                  name="OLE DB Destination Error Output"
+                  synchronousInputId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input]">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Item Recipients\Insert Recipients.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Migrate Order Item Recipients\Insert Recipients.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Item Recipients\Insert Recipients.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+          </components>
+          <paths>
+            <path
+              refId="Package\Migrate Order Item Recipients.Paths[OLE DB Source Output]"
+              endId="Package\Migrate Order Item Recipients\Insert Recipients.Inputs[OLE DB Destination Input]"
+              name="OLE DB Source Output"
+              startId="Package\Migrate Order Item Recipients\Get Recipients.Outputs[OLE DB Source Output]" />
+          </paths>
+        </pipeline>
+      </DTS:ObjectData>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Migrate Order Items"
+      DTS:CreationName="Microsoft.Pipeline"
+      DTS:Description="Data Flow Task"
+      DTS:DTSID="{7D76BA1E-3F6C-4FE3-B684-28641FF9F4AA}"
+      DTS:ExecutableType="Microsoft.Pipeline"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Migrate Order Items"
+      DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <pipeline
+          version="1">
+          <components>
+            <component
+              refId="Package\Migrate Order Items\Get Order Items"
+              componentClassID="Microsoft.OLEDBSource"
+              contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+              description="OLE DB Source"
+              name="Get Order Items"
+              usesDispositions="true"
+              version="7">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the name of the database object used to open a rowset."
+                  name="OpenRowset"></property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the variable that contains the name of the database object used to open a rowset."
+                  name="OpenRowsetVariable"></property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">WITH Items AS
+(
+    SELECT CAST(SUBSTRING(OrderId, 3, 5) AS int) AS OrderId,
+           ROW_NUMBER() OVER (PARTITION BY OrderId, CatalogueItemId ORDER BY Created DESC) AS Latest,
+           CatalogueItemId, ProvisioningTypeId, CataloguePriceTypeId,
+           PricingUnitName, TimeUnitId, EstimationPeriodId, CurrencyCode, Price,
+           Created,
+           CASE WHEN LastUpdated &lt; Created THEN Created ELSE LastUpdated END AS LastUpdated
+      FROM dbo.OrderItem
+)
+SELECT OrderId, CatalogueItemId, ProvisioningTypeId, CataloguePriceTypeId,
+       PricingUnitName, TimeUnitId, EstimationPeriodId, CurrencyCode, Price,
+       Created, LastUpdated
+  FROM Items
+ WHERE Latest = 1;</property>
+                <property
+                  dataType="System.String"
+                  description="The variable that contains the SQL command to be executed."
+                  name="SqlCommandVariable"></property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Forces the use of the DefaultCodePage property value when describing character data."
+                  name="AlwaysUseDefaultCodePage">false</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the mode used to access the database."
+                  name="AccessMode"
+                  typeConverter="AccessMode">2</property>
+                <property
+                  dataType="System.String"
+                  description="The mappings between the parameters in the SQL command and variables."
+                  name="ParameterMapping"></property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Migrate Order Items\Get Order Items.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <outputs>
+                <output
+                  refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output]"
+                  name="OLE DB Source Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[OrderId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[OrderId]"
+                      name="OrderId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                      length="14"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                      name="CatalogueItemId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[ProvisioningTypeId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[ProvisioningTypeId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[ProvisioningTypeId]"
+                      name="ProvisioningTypeId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[CataloguePriceTypeId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CataloguePriceTypeId]"
+                      name="CataloguePriceTypeId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[PricingUnitName]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitName]"
+                      length="20"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[PricingUnitName]"
+                      name="PricingUnitName"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[TimeUnitId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[TimeUnitId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[TimeUnitId]"
+                      name="TimeUnitId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[EstimationPeriodId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[EstimationPeriodId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[EstimationPeriodId]"
+                      name="EstimationPeriodId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CurrencyCode]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[CurrencyCode]"
+                      length="3"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CurrencyCode]"
+                      name="CurrencyCode"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[Price]"
+                      dataType="numeric"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[Price]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[Price]"
+                      name="Price"
+                      precision="18"
+                      scale="4"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[Created]"
+                      dataType="dbTimeStamp2"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[Created]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[Created]"
+                      name="Created"
+                      scale="7"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[LastUpdated]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[LastUpdated]"
+                      name="LastUpdated"
+                      scale="7"
+                      truncationRowDisposition="FailComponent" />
+                  </outputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                      dataType="i4"
+                      name="OrderId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      name="CatalogueItemId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[ProvisioningTypeId]"
+                      dataType="i4"
+                      name="ProvisioningTypeId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      name="CataloguePriceTypeId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitName]"
+                      dataType="wstr"
+                      length="20"
+                      name="PricingUnitName" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[TimeUnitId]"
+                      dataType="i4"
+                      name="TimeUnitId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[EstimationPeriodId]"
+                      dataType="i4"
+                      name="EstimationPeriodId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[CurrencyCode]"
+                      dataType="wstr"
+                      length="3"
+                      name="CurrencyCode" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[Price]"
+                      dataType="numeric"
+                      name="Price"
+                      precision="18"
+                      scale="4" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[Created]"
+                      dataType="dbTimeStamp2"
+                      name="Created"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].ExternalColumns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      name="LastUpdated"
+                      scale="7" />
+                  </externalMetadataColumns>
+                </output>
+                <output
+                  refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output]"
+                  isErrorOut="true"
+                  name="OLE DB Source Error Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                      name="OrderId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                      name="CatalogueItemId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[ProvisioningTypeId]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[ProvisioningTypeId]"
+                      name="ProvisioningTypeId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[CataloguePriceTypeId]"
+                      name="CataloguePriceTypeId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[PricingUnitName]"
+                      dataType="wstr"
+                      length="20"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[PricingUnitName]"
+                      name="PricingUnitName" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[TimeUnitId]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[TimeUnitId]"
+                      name="TimeUnitId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[EstimationPeriodId]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[EstimationPeriodId]"
+                      name="EstimationPeriodId" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[CurrencyCode]"
+                      dataType="wstr"
+                      length="3"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[CurrencyCode]"
+                      name="CurrencyCode" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[Price]"
+                      dataType="numeric"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[Price]"
+                      name="Price"
+                      precision="18"
+                      scale="4" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[Created]"
+                      dataType="dbTimeStamp2"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[Created]"
+                      name="Created"
+                      scale="7" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[LastUpdated]"
+                      name="LastUpdated"
+                      scale="7" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+            <component
+              refId="Package\Migrate Order Items\Insert Order Items"
+              componentClassID="Microsoft.OLEDBDestination"
+              contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+              description="OLE DB Destination"
+              name="Insert Order Items"
+              usesDispositions="true"
+              version="4">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the name of the database object used to open a rowset."
+                  name="OpenRowset">[dbo].[OrderItem]</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the variable that contains the name of the database object used to open a rowset."
+                  name="OpenRowsetVariable"></property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Forces the use of the DefaultCodePage property value when describing character data."
+                  name="AlwaysUseDefaultCodePage">false</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the mode used to access the database."
+                  name="AccessMode"
+                  typeConverter="AccessMode">3</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                  name="FastLoadKeepIdentity">false</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                  name="FastLoadKeepNulls">false</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                  name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                  name="FastLoadMaxInsertCommitSize">2147483647</property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Migrate Order Items\Insert Order Items.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <inputs>
+                <input
+                  refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input]"
+                  errorOrTruncationOperation="Insert"
+                  errorRowDisposition="FailComponent"
+                  hasSideEffects="true"
+                  name="OLE DB Destination Input">
+                  <inputColumns>
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[OrderId]"
+                      cachedDataType="i4"
+                      cachedName="OrderId"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[OrderId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[CatalogueItemId]"
+                      cachedDataType="wstr"
+                      cachedLength="14"
+                      cachedName="CatalogueItemId"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CatalogueItemId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[ProvisioningTypeId]"
+                      cachedDataType="i4"
+                      cachedName="ProvisioningTypeId"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[ProvisioningTypeId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[ProvisioningTypeId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[CataloguePriceTypeId]"
+                      cachedDataType="i4"
+                      cachedName="CataloguePriceTypeId"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[CataloguePriceTypeId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CataloguePriceTypeId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[PricingUnitName]"
+                      cachedDataType="wstr"
+                      cachedLength="20"
+                      cachedName="PricingUnitName"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[PricingUnitName]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[PricingUnitName]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[TimeUnitId]"
+                      cachedDataType="i4"
+                      cachedName="TimeUnitId"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[TimeUnitId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[TimeUnitId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[EstimationPeriodId]"
+                      cachedDataType="i4"
+                      cachedName="EstimationPeriodId"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[EstimationPeriodId]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[EstimationPeriodId]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[CurrencyCode]"
+                      cachedDataType="wstr"
+                      cachedLength="3"
+                      cachedName="CurrencyCode"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[CurrencyCode]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[CurrencyCode]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[Price]"
+                      cachedDataType="numeric"
+                      cachedName="Price"
+                      cachedPrecision="18"
+                      cachedScale="4"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[Price]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[Price]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[Created]"
+                      cachedDataType="dbTimeStamp2"
+                      cachedName="Created"
+                      cachedScale="7"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[Created]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[Created]" />
+                    <inputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].Columns[LastUpdated]"
+                      cachedDataType="dbTimeStamp2"
+                      cachedName="LastUpdated"
+                      cachedScale="7"
+                      externalMetadataColumnId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdated]"
+                      lineageId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output].Columns[LastUpdated]" />
+                  </inputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                      dataType="i4"
+                      name="OrderId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemId]"
+                      dataType="wstr"
+                      length="14"
+                      name="CatalogueItemId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[ProvisioningTypeId]"
+                      dataType="i4"
+                      name="ProvisioningTypeId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[CataloguePriceTypeId]"
+                      dataType="i4"
+                      name="CataloguePriceTypeId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[PricingUnitName]"
+                      dataType="wstr"
+                      length="20"
+                      name="PricingUnitName" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[TimeUnitId]"
+                      dataType="i4"
+                      name="TimeUnitId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[EstimationPeriodId]"
+                      dataType="i4"
+                      name="EstimationPeriodId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[PriceId]"
+                      dataType="i4"
+                      name="PriceId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[CurrencyCode]"
+                      dataType="wstr"
+                      length="3"
+                      name="CurrencyCode" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[Price]"
+                      dataType="numeric"
+                      name="Price"
+                      precision="18"
+                      scale="4" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[DefaultDeliveryDate]"
+                      dataType="dbDate"
+                      name="DefaultDeliveryDate" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[Created]"
+                      dataType="dbTimeStamp2"
+                      name="Created"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      name="LastUpdated"
+                      scale="7" />
+                  </externalMetadataColumns>
+                </input>
+              </inputs>
+              <outputs>
+                <output
+                  refId="Package\Migrate Order Items\Insert Order Items.Outputs[OLE DB Destination Error Output]"
+                  exclusionGroup="1"
+                  isErrorOut="true"
+                  name="OLE DB Destination Error Output"
+                  synchronousInputId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input]">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Insert Order Items.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Migrate Order Items\Insert Order Items.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Order Items\Insert Order Items.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+          </components>
+          <paths>
+            <path
+              refId="Package\Migrate Order Items.Paths[OLE DB Source Output]"
+              endId="Package\Migrate Order Items\Insert Order Items.Inputs[OLE DB Destination Input]"
+              name="OLE DB Source Output"
+              startId="Package\Migrate Order Items\Get Order Items.Outputs[OLE DB Source Output]" />
+          </paths>
+        </pipeline>
+      </DTS:ObjectData>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Migrate Orders"
+      DTS:CreationName="Microsoft.Pipeline"
+      DTS:Description="Data Flow Task"
+      DTS:DTSID="{C2433084-F326-4D37-B762-B81C2DEB9207}"
+      DTS:ExecutableType="Microsoft.Pipeline"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Migrate Orders"
+      DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <pipeline
+          version="1">
+          <components>
+            <component
+              refId="Package\Migrate Orders\Get Order Data"
+              componentClassID="Microsoft.OLEDBSource"
+              contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+              description="OLE DB Source"
+              name="Get Order Data"
+              usesDispositions="true"
+              version="7">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the name of the database object used to open a rowset."
+                  name="OpenRowset"></property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the variable that contains the name of the database object used to open a rowset."
+                  name="OpenRowsetVariable"></property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT CAST(SUBSTRING(OrderId, 3, 5) AS int) AS Id,
+       [Description],
+       OrganisationId AS OrderingPartyId,
+       SupplierId,
+       CommencementDate,
+       FundingSourceOnlyGMS,
+       Created,
+       LastUpdated,
+       LastUpdatedBy,
+       LastUpdatedByName,
+       CASE WHEN LastUpdated &gt; Completed THEN LastUpdated ELSE Completed END AS Completed,
+       OrderStatusId,
+       IsDeleted
+  FROM dbo.[Order];</property>
+                <property
+                  dataType="System.String"
+                  description="The variable that contains the SQL command to be executed."
+                  name="SqlCommandVariable"></property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Forces the use of the DefaultCodePage property value when describing character data."
+                  name="AlwaysUseDefaultCodePage">false</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the mode used to access the database."
+                  name="AccessMode"
+                  typeConverter="AccessMode">2</property>
+                <property
+                  dataType="System.String"
+                  description="The mappings between the parameters in the SQL command and variables."
+                  name="ParameterMapping"></property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Migrate Orders\Get Order Data.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <outputs>
+                <output
+                  refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output]"
+                  name="OLE DB Source Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Id]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Id]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Id]"
+                      name="Id"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Description]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Description]"
+                      length="100"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Description]"
+                      name="Description"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[OrderingPartyId]"
+                      dataType="guid"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[OrderingPartyId]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[OrderingPartyId]"
+                      name="OrderingPartyId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[SupplierId]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierId]"
+                      length="6"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[SupplierId]"
+                      name="SupplierId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[CommencementDate]"
+                      dataType="dbTimeStamp2"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[CommencementDate]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[CommencementDate]"
+                      name="CommencementDate"
+                      scale="7"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[FundingSourceOnlyGMS]"
+                      dataType="bool"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[FundingSourceOnlyGMS]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[FundingSourceOnlyGMS]"
+                      name="FundingSourceOnlyGMS"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Created]"
+                      dataType="dbTimeStamp2"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Created]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Created]"
+                      name="Created"
+                      scale="7"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[LastUpdated]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdated]"
+                      name="LastUpdated"
+                      scale="7"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdatedBy]"
+                      dataType="guid"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[LastUpdatedBy]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdatedBy]"
+                      name="LastUpdatedBy"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdatedByName]"
+                      dataType="wstr"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[LastUpdatedByName]"
+                      length="256"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdatedByName]"
+                      name="LastUpdatedByName"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Completed]"
+                      dataType="dbTimeStamp2"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Completed]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Completed]"
+                      name="Completed"
+                      scale="7"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[OrderStatusId]"
+                      dataType="i4"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[OrderStatusId]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[OrderStatusId]"
+                      name="OrderStatusId"
+                      truncationRowDisposition="FailComponent" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[IsDeleted]"
+                      dataType="bool"
+                      errorOrTruncationOperation="Conversion"
+                      errorRowDisposition="FailComponent"
+                      externalMetadataColumnId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[IsDeleted]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[IsDeleted]"
+                      name="IsDeleted"
+                      truncationRowDisposition="FailComponent" />
+                  </outputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Id]"
+                      dataType="i4"
+                      name="Id" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Description]"
+                      dataType="wstr"
+                      length="100"
+                      name="Description" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[OrderingPartyId]"
+                      dataType="guid"
+                      name="OrderingPartyId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierId]"
+                      dataType="wstr"
+                      length="6"
+                      name="SupplierId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[CommencementDate]"
+                      dataType="dbTimeStamp2"
+                      name="CommencementDate"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[FundingSourceOnlyGMS]"
+                      dataType="bool"
+                      name="FundingSourceOnlyGMS" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Created]"
+                      dataType="dbTimeStamp2"
+                      name="Created"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      name="LastUpdated"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[LastUpdatedBy]"
+                      dataType="guid"
+                      name="LastUpdatedBy" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[LastUpdatedByName]"
+                      dataType="wstr"
+                      length="256"
+                      name="LastUpdatedByName" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[Completed]"
+                      dataType="dbTimeStamp2"
+                      name="Completed"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[OrderStatusId]"
+                      dataType="i4"
+                      name="OrderStatusId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].ExternalColumns[IsDeleted]"
+                      dataType="bool"
+                      name="IsDeleted" />
+                  </externalMetadataColumns>
+                </output>
+                <output
+                  refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output]"
+                  isErrorOut="true"
+                  name="OLE DB Source Error Output">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Id]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Id]"
+                      name="Id" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Description]"
+                      dataType="wstr"
+                      length="100"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Description]"
+                      name="Description" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[OrderingPartyId]"
+                      dataType="guid"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[OrderingPartyId]"
+                      name="OrderingPartyId" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[SupplierId]"
+                      dataType="wstr"
+                      length="6"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[SupplierId]"
+                      name="SupplierId" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[CommencementDate]"
+                      dataType="dbTimeStamp2"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[CommencementDate]"
+                      name="CommencementDate"
+                      scale="7" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[FundingSourceOnlyGMS]"
+                      dataType="bool"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[FundingSourceOnlyGMS]"
+                      name="FundingSourceOnlyGMS" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Created]"
+                      dataType="dbTimeStamp2"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Created]"
+                      name="Created"
+                      scale="7" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[LastUpdated]"
+                      name="LastUpdated"
+                      scale="7" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[LastUpdatedBy]"
+                      dataType="guid"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[LastUpdatedBy]"
+                      name="LastUpdatedBy" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[LastUpdatedByName]"
+                      dataType="wstr"
+                      length="256"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[LastUpdatedByName]"
+                      name="LastUpdatedByName" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Completed]"
+                      dataType="dbTimeStamp2"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[Completed]"
+                      name="Completed"
+                      scale="7" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[OrderStatusId]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[OrderStatusId]"
+                      name="OrderStatusId" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[IsDeleted]"
+                      dataType="bool"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[IsDeleted]"
+                      name="IsDeleted" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+            <component
+              refId="Package\Migrate Orders\Insert Into Order Table"
+              componentClassID="Microsoft.OLEDBDestination"
+              contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+              description="OLE DB Destination"
+              name="Insert Into Order Table"
+              usesDispositions="true"
+              version="4">
+              <properties>
+                <property
+                  dataType="System.Int32"
+                  description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                  name="CommandTimeout">0</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the name of the database object used to open a rowset."
+                  name="OpenRowset">[dbo].[Order]</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies the variable that contains the name of the database object used to open a rowset."
+                  name="OpenRowsetVariable"></property>
+                <property
+                  dataType="System.String"
+                  description="The SQL command to be executed."
+                  name="SqlCommand"
+                  UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the column code page to use when code page information is unavailable from the data source."
+                  name="DefaultCodePage">1252</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Forces the use of the DefaultCodePage property value when describing character data."
+                  name="AlwaysUseDefaultCodePage">false</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies the mode used to access the database."
+                  name="AccessMode"
+                  typeConverter="AccessMode">3</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                  name="FastLoadKeepIdentity">true</property>
+                <property
+                  dataType="System.Boolean"
+                  description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                  name="FastLoadKeepNulls">false</property>
+                <property
+                  dataType="System.String"
+                  description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                  name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                <property
+                  dataType="System.Int32"
+                  description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                  name="FastLoadMaxInsertCommitSize">2147483647</property>
+              </properties>
+              <connections>
+                <connection
+                  refId="Package\Migrate Orders\Insert Into Order Table.Connections[OleDbConnection]"
+                  connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                  connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                  description="The OLE DB runtime connection used to access the database."
+                  name="OleDbConnection" />
+              </connections>
+              <inputs>
+                <input
+                  refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input]"
+                  errorOrTruncationOperation="Insert"
+                  errorRowDisposition="FailComponent"
+                  hasSideEffects="true"
+                  name="OLE DB Destination Input">
+                  <inputColumns>
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[Id]"
+                      cachedDataType="i4"
+                      cachedName="Id"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Id]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[Description]"
+                      cachedDataType="wstr"
+                      cachedLength="100"
+                      cachedName="Description"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Description]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Description]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[OrderingPartyId]"
+                      cachedDataType="guid"
+                      cachedName="OrderingPartyId"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderingPartyId]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[OrderingPartyId]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[SupplierId]"
+                      cachedDataType="wstr"
+                      cachedLength="6"
+                      cachedName="SupplierId"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[SupplierId]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[SupplierId]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[CommencementDate]"
+                      cachedDataType="dbTimeStamp2"
+                      cachedName="CommencementDate"
+                      cachedScale="7"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[CommencementDate]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[CommencementDate]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[FundingSourceOnlyGMS]"
+                      cachedDataType="bool"
+                      cachedName="FundingSourceOnlyGMS"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[FundingSourceOnlyGMS]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[FundingSourceOnlyGMS]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[Created]"
+                      cachedDataType="dbTimeStamp2"
+                      cachedName="Created"
+                      cachedScale="7"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Created]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Created]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[LastUpdated]"
+                      cachedDataType="dbTimeStamp2"
+                      cachedName="LastUpdated"
+                      cachedScale="7"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdated]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdated]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[LastUpdatedBy]"
+                      cachedDataType="guid"
+                      cachedName="LastUpdatedBy"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdatedBy]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdatedBy]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[LastUpdatedByName]"
+                      cachedDataType="wstr"
+                      cachedLength="256"
+                      cachedName="LastUpdatedByName"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdatedByName]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[LastUpdatedByName]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[Completed]"
+                      cachedDataType="dbTimeStamp2"
+                      cachedName="Completed"
+                      cachedScale="7"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Completed]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[Completed]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[OrderStatusId]"
+                      cachedDataType="i4"
+                      cachedName="OrderStatusId"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderStatusId]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[OrderStatusId]" />
+                    <inputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].Columns[IsDeleted]"
+                      cachedDataType="bool"
+                      cachedName="IsDeleted"
+                      externalMetadataColumnId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[IsDeleted]"
+                      lineageId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output].Columns[IsDeleted]" />
+                  </inputColumns>
+                  <externalMetadataColumns
+                    isUsed="True">
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                      dataType="i4"
+                      name="Id" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Revision]"
+                      dataType="ui1"
+                      name="Revision" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[CallOffId]"
+                      dataType="wstr"
+                      length="4000"
+                      name="CallOffId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Description]"
+                      dataType="wstr"
+                      length="100"
+                      name="Description" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderingPartyId]"
+                      dataType="guid"
+                      name="OrderingPartyId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderingPartyContactId]"
+                      dataType="i4"
+                      name="OrderingPartyContactId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[SupplierId]"
+                      dataType="wstr"
+                      length="6"
+                      name="SupplierId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[SupplierContactId]"
+                      dataType="i4"
+                      name="SupplierContactId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[CommencementDate]"
+                      dataType="dbDate"
+                      name="CommencementDate" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[FundingSourceOnlyGMS]"
+                      dataType="bool"
+                      name="FundingSourceOnlyGMS" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Created]"
+                      dataType="dbTimeStamp2"
+                      name="Created"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdated]"
+                      dataType="dbTimeStamp2"
+                      name="LastUpdated"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdatedBy]"
+                      dataType="guid"
+                      name="LastUpdatedBy" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[LastUpdatedByName]"
+                      dataType="wstr"
+                      length="256"
+                      name="LastUpdatedByName" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[Completed]"
+                      dataType="dbTimeStamp2"
+                      name="Completed"
+                      scale="7" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderStatusId]"
+                      dataType="i4"
+                      name="OrderStatusId" />
+                    <externalMetadataColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input].ExternalColumns[IsDeleted]"
+                      dataType="bool"
+                      name="IsDeleted" />
+                  </externalMetadataColumns>
+                </input>
+              </inputs>
+              <outputs>
+                <output
+                  refId="Package\Migrate Orders\Insert Into Order Table.Outputs[OLE DB Destination Error Output]"
+                  exclusionGroup="1"
+                  isErrorOut="true"
+                  name="OLE DB Destination Error Output"
+                  synchronousInputId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input]">
+                  <outputColumns>
+                    <outputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Orders\Insert Into Order Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                      name="ErrorCode"
+                      specialFlags="1" />
+                    <outputColumn
+                      refId="Package\Migrate Orders\Insert Into Order Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                      dataType="i4"
+                      lineageId="Package\Migrate Orders\Insert Into Order Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                      name="ErrorColumn"
+                      specialFlags="2" />
+                  </outputColumns>
+                  <externalMetadataColumns />
+                </output>
+              </outputs>
+            </component>
+          </components>
+          <paths>
+            <path
+              refId="Package\Migrate Orders.Paths[OLE DB Source Output]"
+              endId="Package\Migrate Orders\Insert Into Order Table.Inputs[OLE DB Destination Input]"
+              name="OLE DB Source Output"
+              startId="Package\Migrate Orders\Get Order Data.Outputs[OLE DB Source Output]" />
+          </paths>
+        </pipeline>
+      </DTS:ObjectData>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Migrate Organization Data"
+      DTS:CreationName="STOCK:SEQUENCE"
+      DTS:Description="Sequence Container"
+      DTS:DTSID="{8480C13E-0167-4033-876F-44C6ECE018D5}"
+      DTS:ExecutableType="STOCK:SEQUENCE"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Migrate Organization Data">
+      <DTS:Variables />
+      <DTS:Executables>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Organization Data\Get Organization IDs"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{FB504B42-83D5-4AA2-A27C-2DF7EE8B3D43}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Organization IDs"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+              SQLTask:SqlStmtSourceType="Variable"
+              SQLTask:SqlStatementSource="User::getOrganizationIDsSql"
+              SQLTask:ResultType="ResultSetType_Rowset" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="0"
+                SQLTask:DtsVariableName="User::organizationIDs" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Organization Data\Migrate Base Organization Data"
+          DTS:CreationName="STOCK:SEQUENCE"
+          DTS:Description="Sequence Container"
+          DTS:DTSID="{4DC29E87-EDDA-4EC2-87B7-59641DA36E39}"
+          DTS:ExecutableType="STOCK:SEQUENCE"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Base Organization Data">
+          <DTS:Variables />
+          <DTS:Executables>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data"
+              DTS:CreationName="Microsoft.Pipeline"
+              DTS:DelayValidation="True"
+              DTS:Description="Data Flow Task"
+              DTS:DTSID="{ED66CD24-49A0-40A6-894A-59EE4610340C}"
+              DTS:ExecutableType="Microsoft.Pipeline"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Add Temporary Organization Address Data"
+              DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <pipeline
+                  version="1">
+                  <components>
+                    <component
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data"
+                      componentClassID="Microsoft.OLEDBSource"
+                      contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                      description="OLE DB Source"
+                      name="Get Address Data"
+                      usesDispositions="true"
+                      version="7">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable"></property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.String"
+                          description="The variable that contains the SQL command to be executed."
+                          name="SqlCommandVariable">User::organizationAddressIDsCommand</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">3</property>
+                        <property
+                          dataType="System.String"
+                          description="The mappings between the parameters in the SQL command and variables."
+                          name="ParameterMapping"></property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output]"
+                          name="OLE DB Source Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[OrganisationId]"
+                              dataType="guid"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[OrganisationId]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[OrganisationId]"
+                              name="OrganisationId"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line1]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line1]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line1]"
+                              name="Line1"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line2]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line2]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line2]"
+                              name="Line2"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line3]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line3]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line3]"
+                              name="Line3"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line4]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line4]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line4]"
+                              name="Line4"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line5]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line5]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line5]"
+                              name="Line5"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Town]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Town]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Town]"
+                              name="Town"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[County]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[County]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[County]"
+                              name="County"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Postcode]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Postcode]"
+                              length="10"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Postcode]"
+                              name="Postcode"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Country]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Country]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Country]"
+                              name="Country"
+                              truncationRowDisposition="FailComponent" />
+                          </outputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[OrganisationId]"
+                              dataType="guid"
+                              name="OrganisationId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line1]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line1" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line2]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line2" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line3]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line3" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line4]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line4" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line5]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line5" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Town]"
+                              dataType="wstr"
+                              length="256"
+                              name="Town" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[County]"
+                              dataType="wstr"
+                              length="256"
+                              name="County" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Postcode]"
+                              dataType="wstr"
+                              length="10"
+                              name="Postcode" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].ExternalColumns[Country]"
+                              dataType="wstr"
+                              length="256"
+                              name="Country" />
+                          </externalMetadataColumns>
+                        </output>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output]"
+                          isErrorOut="true"
+                          name="OLE DB Source Error Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[OrganisationId]"
+                              dataType="guid"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[OrganisationId]"
+                              name="OrganisationId" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line1]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line1]"
+                              name="Line1" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line2]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line2]"
+                              name="Line2" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line3]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line3]"
+                              name="Line3" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line4]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line4]"
+                              name="Line4" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line5]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Line5]"
+                              name="Line5" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Town]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Town]"
+                              name="Town" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[County]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[County]"
+                              name="County" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Postcode]"
+                              dataType="wstr"
+                              length="10"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Postcode]"
+                              name="Postcode" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Country]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[Country]"
+                              name="Country" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table"
+                      componentClassID="Microsoft.OLEDBDestination"
+                      contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                      description="OLE DB Destination"
+                      name="Insert Into Addresses Temp Table"
+                      usesDispositions="true"
+                      version="4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable">User::addressesTempTableName</property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">4</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepIdentity">false</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepNulls">false</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                          name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                          name="FastLoadMaxInsertCommitSize">2147483647</property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input]"
+                          errorOrTruncationOperation="Insert"
+                          errorRowDisposition="FailComponent"
+                          hasSideEffects="true"
+                          name="OLE DB Destination Input">
+                          <inputColumns>
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line1]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line1"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line1]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line1]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line2]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line2"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line2]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line2]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line3]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line3"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line3]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line3]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line4]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line4"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line4]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line4]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line5]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line5"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line5]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Line5]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Town]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Town"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Town]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Town]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[County]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="County"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[County]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[County]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Postcode]"
+                              cachedDataType="wstr"
+                              cachedLength="10"
+                              cachedName="Postcode"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Postcode]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Postcode]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Country]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Country"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Country]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[Country]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[OrganisationId]"
+                              cachedDataType="guid"
+                              cachedName="OrganisationId"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[OrganizationId]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output].Columns[OrganisationId]" />
+                          </inputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[OrganizationId]"
+                              dataType="guid"
+                              name="OrganizationId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line1]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line1" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line2]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line2" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line3]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line3" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line4]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line4" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line5]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line5" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Town]"
+                              dataType="wstr"
+                              length="256"
+                              name="Town" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[County]"
+                              dataType="wstr"
+                              length="256"
+                              name="County" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Postcode]"
+                              dataType="wstr"
+                              length="10"
+                              name="Postcode" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Country]"
+                              dataType="wstr"
+                              length="256"
+                              name="Country" />
+                          </externalMetadataColumns>
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Outputs[OLE DB Destination Error Output]"
+                          exclusionGroup="1"
+                          isErrorOut="true"
+                          name="OLE DB Destination Error Output"
+                          synchronousInputId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input]">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                  </components>
+                  <paths>
+                    <path
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data.Paths[OLE DB Source Output]"
+                      endId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table.Inputs[OLE DB Destination Input]"
+                      name="OLE DB Source Output"
+                      startId="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data.Outputs[OLE DB Source Output]" />
+                  </paths>
+                </pipeline>
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Organization Data\Migrate Base Organization Data\Create Addresses Temp Table"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{D90DB734-4F63-4797-9E1D-546B01C4B396}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Create Addresses Temp Table"
+              DTS:ThreadHint="1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::createAddressesTempTableSql" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Organization Data\Migrate Base Organization Data\Create Organization IDs Temp Table"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{56F98659-6B65-4926-9A77-BC16CF0FC625}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Create Organization IDs Temp Table"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{200CEF1E-4EB0-48F8-9FCC-B07A263D9CA6}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::createOrganizationIDsTempTableSql" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data"
+              DTS:CreationName="Microsoft.Pipeline"
+              DTS:DelayValidation="True"
+              DTS:Description="Data Flow Task"
+              DTS:DTSID="{22E95F89-0AAD-4DBF-80DF-48C9F09495EC}"
+              DTS:ExecutableType="Microsoft.Pipeline"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Migrate Organization Data"
+              DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <pipeline
+                  version="1">
+                  <components>
+                    <component
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table"
+                      componentClassID="Microsoft.OLEDBDestination"
+                      contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                      description="OLE DB Destination"
+                      name="Add IDs to Temp Table"
+                      usesDispositions="true"
+                      version="4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable">User::organizationIDsTempTableName</property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">4</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepIdentity">false</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepNulls">false</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                          name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                          name="FastLoadMaxInsertCommitSize">2147483647</property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Inputs[OLE DB Destination Input]"
+                          errorOrTruncationOperation="Insert"
+                          errorRowDisposition="FailComponent"
+                          hasSideEffects="true"
+                          name="OLE DB Destination Input">
+                          <inputColumns>
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Inputs[OLE DB Destination Input].Columns[Id]"
+                              cachedDataType="guid"
+                              cachedName="Id"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[Id]" />
+                          </inputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              dataType="guid"
+                              name="Id" />
+                          </externalMetadataColumns>
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Outputs[OLE DB Destination Error Output]"
+                          exclusionGroup="1"
+                          isErrorOut="true"
+                          name="OLE DB Destination Error Output"
+                          synchronousInputId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Inputs[OLE DB Destination Input]">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data"
+                      componentClassID="Microsoft.OLEDBSource"
+                      contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                      description="OLE DB Source"
+                      name="Get Organization Data"
+                      usesDispositions="true"
+                      version="7">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable"></property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT DISTINCT OrganisationId AS Id,
+       TRIM(OrganisationOdsCode) AS OdsCode,
+       TRIM(OrganisationName) AS [Name]
+  FROM dbo.[Order]
+ WHERE OrganisationOdsCode IS NOT NULL;</property>
+                        <property
+                          dataType="System.String"
+                          description="The variable that contains the SQL command to be executed."
+                          name="SqlCommandVariable"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">2</property>
+                        <property
+                          dataType="System.String"
+                          description="The mappings between the parameters in the SQL command and variables."
+                          name="ParameterMapping"></property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output]"
+                          name="OLE DB Source Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[Id]"
+                              dataType="guid"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].ExternalColumns[Id]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[Id]"
+                              name="Id"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[OdsCode]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].ExternalColumns[OdsCode]"
+                              length="8"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[OdsCode]"
+                              name="OdsCode"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[Name]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].ExternalColumns[Name]"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[Name]"
+                              name="Name"
+                              truncationRowDisposition="FailComponent" />
+                          </outputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].ExternalColumns[Id]"
+                              dataType="guid"
+                              name="Id" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].ExternalColumns[OdsCode]"
+                              dataType="wstr"
+                              length="8"
+                              name="OdsCode" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].ExternalColumns[Name]"
+                              dataType="wstr"
+                              length="256"
+                              name="Name" />
+                          </externalMetadataColumns>
+                        </output>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output]"
+                          isErrorOut="true"
+                          name="OLE DB Source Error Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[Id]"
+                              dataType="guid"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[Id]"
+                              name="Id" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[OdsCode]"
+                              dataType="wstr"
+                              length="8"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[OdsCode]"
+                              name="OdsCode" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[Name]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[Name]"
+                              name="Name" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data"
+                      componentClassID="Microsoft.OLEDBDestination"
+                      contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                      description="OLE DB Destination"
+                      name="Insert Organization Data"
+                      usesDispositions="true"
+                      version="4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset">[dbo].[OrderingParty]</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable"></property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">3</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepIdentity">false</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepNulls">false</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                          name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                          name="FastLoadMaxInsertCommitSize">2147483647</property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input]"
+                          errorOrTruncationOperation="Insert"
+                          errorRowDisposition="FailComponent"
+                          hasSideEffects="true"
+                          name="OLE DB Destination Input">
+                          <inputColumns>
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].Columns[Id]"
+                              cachedDataType="guid"
+                              cachedName="Id"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[Id]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].Columns[OdsCode]"
+                              cachedDataType="wstr"
+                              cachedLength="8"
+                              cachedName="OdsCode"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].ExternalColumns[OdsCode]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[OdsCode]" />
+                            <inputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].Columns[Name]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Name"
+                              externalMetadataColumnId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output].Columns[Name]" />
+                          </inputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              dataType="guid"
+                              name="Id" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].ExternalColumns[OdsCode]"
+                              dataType="wstr"
+                              length="8"
+                              name="OdsCode" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                              dataType="wstr"
+                              length="256"
+                              name="Name" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input].ExternalColumns[AddressId]"
+                              dataType="i4"
+                              name="AddressId" />
+                          </externalMetadataColumns>
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Outputs[OLE DB Destination Error Output]"
+                          exclusionGroup="1"
+                          isErrorOut="true"
+                          name="OLE DB Destination Error Output"
+                          synchronousInputId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input]">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast"
+                      componentClassID="Microsoft.Multicast"
+                      contactInfo="Multicast;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;0"
+                      description="Distributes every input row to every row in one or more outputs. For example, branch your data flow to make a copy of data so that some values can be masked before sharing with external partners."
+                      name="Multicast">
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Inputs[Multicast Input 1]"
+                          name="Multicast Input 1">
+                          <externalMetadataColumns />
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Outputs[Multicast Output 1]"
+                          deleteOutputOnPathDetached="true"
+                          name="Multicast Output 1"
+                          synchronousInputId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Inputs[Multicast Input 1]">
+                          <externalMetadataColumns />
+                        </output>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Outputs[Multicast Output 2]"
+                          deleteOutputOnPathDetached="true"
+                          name="Multicast Output 2"
+                          synchronousInputId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Inputs[Multicast Input 1]">
+                          <externalMetadataColumns />
+                        </output>
+                        <output
+                          refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Outputs[Multicast Output 3]"
+                          dangling="true"
+                          deleteOutputOnPathDetached="true"
+                          name="Multicast Output 3"
+                          synchronousInputId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Inputs[Multicast Input 1]">
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                  </components>
+                  <paths>
+                    <path
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data.Paths[Multicast Output 1]"
+                      endId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data.Inputs[OLE DB Destination Input]"
+                      name="Multicast Output 1"
+                      startId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Outputs[Multicast Output 1]" />
+                    <path
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data.Paths[Multicast Output 2]"
+                      endId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table.Inputs[OLE DB Destination Input]"
+                      name="Multicast Output 2"
+                      startId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Outputs[Multicast Output 2]" />
+                    <path
+                      refId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data.Paths[OLE DB Source Output]"
+                      endId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast.Inputs[Multicast Input 1]"
+                      name="OLE DB Source Output"
+                      startId="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data.Outputs[OLE DB Source Output]" />
+                  </paths>
+                </pipeline>
+              </DTS:ObjectData>
+            </DTS:Executable>
+          </DTS:Executables>
+          <DTS:PrecedenceConstraints>
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Organization Data\Migrate Base Organization Data.PrecedenceConstraints[Constraint]"
+              DTS:CreationName=""
+              DTS:DTSID="{03A5C1C1-6BC7-440E-85C4-631C1122490F}"
+              DTS:From="Package\Migrate Organization Data\Migrate Base Organization Data\Create Organization IDs Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint"
+              DTS:To="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data" />
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Organization Data\Migrate Base Organization Data.PrecedenceConstraints[Constraint 1]"
+              DTS:CreationName=""
+              DTS:DTSID="{FD19DB95-4769-4106-A969-23A8F6412156}"
+              DTS:From="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint 1"
+              DTS:To="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data" />
+          </DTS:PrecedenceConstraints>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Organization Data\Migrate Organization Address Data"
+          DTS:CreationName="STOCK:FOREACHLOOP"
+          DTS:Description="Foreach Loop Container"
+          DTS:DTSID="{E39ACC37-E04C-42CA-B2FC-C6B935BE927C}"
+          DTS:ExecutableType="STOCK:FOREACHLOOP"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Organization Address Data">
+          <DTS:ForEachEnumerator
+            DTS:CreationName="Microsoft.ForEachADOEnumerator"
+            DTS:DTSID="{5D76724A-CC97-4F72-853E-0D4B5533A223}"
+            DTS:ObjectName="{5D76724A-CC97-4F72-853E-0D4B5533A223}">
+            <DTS:ObjectData>
+              <FEEADO
+                EnumType="EnumerateRowsInFirstTable"
+                VarName="User::organizationIDs" />
+            </DTS:ObjectData>
+          </DTS:ForEachEnumerator>
+          <DTS:Variables />
+          <DTS:Executables>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Organization Data\Migrate Organization Address Data\Add Organization Address Data"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{3FB65F89-1258-4315-8FF0-EB6683A6A3DE}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Add Organization Address Data"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::addOrganizationAddressDataSql"
+                  SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+                  <SQLTask:ResultBinding
+                    SQLTask:ResultName="0"
+                    SQLTask:DtsVariableName="User::identityValue" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="0"
+                    SQLTask:DtsVariableName="User::organizationId"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="72"
+                    SQLTask:ParameterSize="-1" />
+                </SQLTask:SqlTaskData>
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Organization Data\Migrate Organization Address Data\Update Organization Address ID"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{42C48F11-A506-4267-B412-E7C835A20939}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Update Organization Address ID"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStatementSource="UPDATE dbo.OrderingParty&#xA;   SET AddressId = ?&#xA; WHERE Id = ?;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="0"
+                    SQLTask:DtsVariableName="User::identityValue"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="3"
+                    SQLTask:ParameterSize="-1" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="1"
+                    SQLTask:DtsVariableName="User::organizationId"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="72"
+                    SQLTask:ParameterSize="-1" />
+                </SQLTask:SqlTaskData>
+              </DTS:ObjectData>
+            </DTS:Executable>
+          </DTS:Executables>
+          <DTS:PrecedenceConstraints>
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Organization Data\Migrate Organization Address Data.PrecedenceConstraints[Constraint]"
+              DTS:CreationName=""
+              DTS:DTSID="{9B27F95E-3C44-4859-BB5F-01BB71BCBFA3}"
+              DTS:From="Package\Migrate Organization Data\Migrate Organization Address Data\Add Organization Address Data"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint"
+              DTS:To="Package\Migrate Organization Data\Migrate Organization Address Data\Update Organization Address ID" />
+          </DTS:PrecedenceConstraints>
+          <DTS:ForEachVariableMappings>
+            <DTS:ForEachVariableMapping
+              DTS:CreationName=""
+              DTS:DTSID="{B8B221E2-AEFB-466A-A89E-59ACA2691196}"
+              DTS:ObjectName="{B8B221E2-AEFB-466A-A89E-59ACA2691196}"
+              DTS:ValueIndex="0"
+              DTS:VariableName="User::organizationId" />
+          </DTS:ForEachVariableMappings>
+        </DTS:Executable>
+      </DTS:Executables>
+      <DTS:PrecedenceConstraints>
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Migrate Organization Data.PrecedenceConstraints[Constraint]"
+          DTS:CreationName=""
+          DTS:DTSID="{2A2590FE-C468-462C-ACA9-744997B8E093}"
+          DTS:From="Package\Migrate Organization Data\Migrate Base Organization Data"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint"
+          DTS:To="Package\Migrate Organization Data\Get Organization IDs" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Migrate Organization Data.PrecedenceConstraints[Constraint 1]"
+          DTS:CreationName=""
+          DTS:DTSID="{5F70F78D-55CB-476D-A629-EFA641E53104}"
+          DTS:From="Package\Migrate Organization Data\Get Organization IDs"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 1"
+          DTS:To="Package\Migrate Organization Data\Migrate Organization Address Data" />
+      </DTS:PrecedenceConstraints>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Migrate Supplier Data"
+      DTS:CreationName="STOCK:SEQUENCE"
+      DTS:Description="Sequence Container"
+      DTS:DTSID="{76A4D179-54C7-4974-9CDE-108BAE296289}"
+      DTS:ExecutableType="STOCK:SEQUENCE"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Migrate Supplier Data">
+      <DTS:Variables />
+      <DTS:Executables>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Supplier Data\Get Suppliers"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{D89076DE-40C7-4931-94C9-DE4CF5E96810}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Suppliers"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+              SQLTask:SqlStmtSourceType="Variable"
+              SQLTask:SqlStatementSource="User::getSupplierIDsSql"
+              SQLTask:ResultType="ResultSetType_Rowset" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="0"
+                SQLTask:DtsVariableName="User::supplierIDs" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data"
+          DTS:CreationName="STOCK:SEQUENCE"
+          DTS:Description="Sequence Container"
+          DTS:DTSID="{6546A8AB-A55F-4886-9B05-BDFB3BCE2A96}"
+          DTS:ExecutableType="STOCK:SEQUENCE"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Base Supplier Data">
+          <DTS:Variables />
+          <DTS:Executables>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data"
+              DTS:CreationName="Microsoft.Pipeline"
+              DTS:DelayValidation="True"
+              DTS:Description="Data Flow Task"
+              DTS:DTSID="{DB27BE03-CCCB-4ADD-AA47-6A1F496EC246}"
+              DTS:ExecutableType="Microsoft.Pipeline"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Add Temporary Supplier Address Data"
+              DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <pipeline
+                  version="1">
+                  <components>
+                    <component
+                      refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data"
+                      componentClassID="Microsoft.OLEDBSource"
+                      contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                      description="OLE DB Source"
+                      name="Get Supplier Address Data"
+                      usesDispositions="true"
+                      version="7">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable"></property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">WITH AddressIds AS
+(
+    SELECT DISTINCT SupplierId,
+           MAX(SupplierAddressId) OVER (PARTITION BY SupplierId) AS AddressId
+      FROM dbo.[Order]
+     WHERE SupplierId IN (SELECT DISTINCT SupplierId FROM dbo.[Order] WHERE SupplierId IS NOT NULL)
+)
+SELECT i.SupplierId, a.Line1, a.Line2, a.Line3, a.Line4, a.Line5, a.Town, a.County, a.Postcode, a.Country
+  FROM AddressIds AS i
+       INNER JOIN dbo.[Address] AS a ON a.AddressId = i.AddressId;</property>
+                        <property
+                          dataType="System.String"
+                          description="The variable that contains the SQL command to be executed."
+                          name="SqlCommandVariable"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">2</property>
+                        <property
+                          dataType="System.String"
+                          description="The mappings between the parameters in the SQL command and variables."
+                          name="ParameterMapping"></property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output]"
+                          name="OLE DB Source Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[SupplierId]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierId]"
+                              length="6"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[SupplierId]"
+                              name="SupplierId"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line1]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line1]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line1]"
+                              name="Line1"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line2]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line2]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line2]"
+                              name="Line2"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line3]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line3]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line3]"
+                              name="Line3"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line4]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line4]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line4]"
+                              name="Line4"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line5]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line5]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line5]"
+                              name="Line5"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Town]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Town]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Town]"
+                              name="Town"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[County]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[County]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[County]"
+                              name="County"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Postcode]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Postcode]"
+                              length="10"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Postcode]"
+                              name="Postcode"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Country]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Country]"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Country]"
+                              name="Country"
+                              truncationRowDisposition="FailComponent" />
+                          </outputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierId]"
+                              dataType="wstr"
+                              length="6"
+                              name="SupplierId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line1]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line1" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line2]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line2" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line3]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line3" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line4]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line4" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Line5]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line5" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Town]"
+                              dataType="wstr"
+                              length="256"
+                              name="Town" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[County]"
+                              dataType="wstr"
+                              length="256"
+                              name="County" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Postcode]"
+                              dataType="wstr"
+                              length="10"
+                              name="Postcode" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].ExternalColumns[Country]"
+                              dataType="wstr"
+                              length="256"
+                              name="Country" />
+                          </externalMetadataColumns>
+                        </output>
+                        <output
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output]"
+                          isErrorOut="true"
+                          name="OLE DB Source Error Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[SupplierId]"
+                              dataType="wstr"
+                              length="6"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[SupplierId]"
+                              name="SupplierId" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line1]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line1]"
+                              name="Line1" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line2]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line2]"
+                              name="Line2" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line3]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line3]"
+                              name="Line3" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line4]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line4]"
+                              name="Line4" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line5]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Line5]"
+                              name="Line5" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Town]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Town]"
+                              name="Town" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[County]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[County]"
+                              name="County" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Postcode]"
+                              dataType="wstr"
+                              length="10"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Postcode]"
+                              name="Postcode" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Country]"
+                              dataType="wstr"
+                              length="256"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[Country]"
+                              name="Country" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table"
+                      componentClassID="Microsoft.OLEDBDestination"
+                      contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                      description="OLE DB Destination"
+                      name="Insert Into Supplier Addresses Temp Table"
+                      usesDispositions="true"
+                      version="4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable">User::supplierAddressesTempTableName</property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">4</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepIdentity">false</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepNulls">false</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                          name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                          name="FastLoadMaxInsertCommitSize">2147483647</property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input]"
+                          errorOrTruncationOperation="Insert"
+                          errorRowDisposition="FailComponent"
+                          hasSideEffects="true"
+                          name="OLE DB Destination Input">
+                          <inputColumns>
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[SupplierId]"
+                              cachedDataType="wstr"
+                              cachedLength="6"
+                              cachedName="SupplierId"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[SupplierId]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[SupplierId]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line1]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line1"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line1]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line1]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line2]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line2"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line2]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line2]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line3]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line3"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line3]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line3]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line4]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line4"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line4]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line4]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Line5]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Line5"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line5]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Line5]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Town]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Town"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Town]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Town]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[County]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="County"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[County]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[County]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Postcode]"
+                              cachedDataType="wstr"
+                              cachedLength="10"
+                              cachedName="Postcode"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Postcode]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Postcode]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].Columns[Country]"
+                              cachedDataType="wstr"
+                              cachedLength="256"
+                              cachedName="Country"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Country]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output].Columns[Country]" />
+                          </inputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[SupplierId]"
+                              dataType="wstr"
+                              length="6"
+                              name="SupplierId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line1]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line1" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line2]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line2" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line3]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line3" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line4]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line4" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Line5]"
+                              dataType="wstr"
+                              length="256"
+                              name="Line5" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Town]"
+                              dataType="wstr"
+                              length="256"
+                              name="Town" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[County]"
+                              dataType="wstr"
+                              length="256"
+                              name="County" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Postcode]"
+                              dataType="wstr"
+                              length="10"
+                              name="Postcode" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Country]"
+                              dataType="wstr"
+                              length="256"
+                              name="Country" />
+                          </externalMetadataColumns>
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Outputs[OLE DB Destination Error Output]"
+                          exclusionGroup="1"
+                          isErrorOut="true"
+                          name="OLE DB Destination Error Output"
+                          synchronousInputId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input]">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                  </components>
+                  <paths>
+                    <path
+                      refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data.Paths[OLE DB Source Output]"
+                      endId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table.Inputs[OLE DB Destination Input]"
+                      name="OLE DB Source Output"
+                      startId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data.Outputs[OLE DB Source Output]" />
+                  </paths>
+                </pipeline>
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Supplier Addresses Temp Table"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{B7D84E41-54D2-46CB-AB31-B3DF62ED17FC}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Create Supplier Addresses Temp Table"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::createSupplierAddressesTempTableSql" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Suppliers Temp Table"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{0AE77C3C-7237-464D-B360-95814975683F}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Create Suppliers Temp Table"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::createSuppliersTempTableSql" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data"
+              DTS:CreationName="Microsoft.Pipeline"
+              DTS:DelayValidation="True"
+              DTS:Description="Data Flow Task"
+              DTS:DTSID="{DFD582CE-5CAB-456C-AE7A-5CC1B4538905}"
+              DTS:ExecutableType="Microsoft.Pipeline"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Migrate Supplier Data"
+              DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <pipeline
+                  version="1">
+                  <components>
+                    <component
+                      refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table"
+                      componentClassID="Microsoft.OLEDBDestination"
+                      contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                      description="OLE DB Destination"
+                      name="Add Supplier Data to Temp Table"
+                      usesDispositions="true"
+                      version="4">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable">User::suppliersTempTableName</property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">4</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepIdentity">false</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                          name="FastLoadKeepNulls">false</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                          name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                          name="FastLoadMaxInsertCommitSize">2147483647</property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <inputs>
+                        <input
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input]"
+                          errorOrTruncationOperation="Insert"
+                          errorRowDisposition="FailComponent"
+                          hasSideEffects="true"
+                          name="OLE DB Destination Input">
+                          <inputColumns>
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input].Columns[SupplierId]"
+                              cachedDataType="wstr"
+                              cachedLength="6"
+                              cachedName="SupplierId"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].Columns[SupplierId]" />
+                            <inputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input].Columns[SupplierName]"
+                              cachedDataType="wstr"
+                              cachedLength="255"
+                              cachedName="SupplierName"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].Columns[SupplierName]" />
+                          </inputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                              dataType="wstr"
+                              length="6"
+                              name="Id" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                              dataType="wstr"
+                              length="256"
+                              name="Name" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input].ExternalColumns[AddressId]"
+                              dataType="i4"
+                              name="AddressId" />
+                          </externalMetadataColumns>
+                        </input>
+                      </inputs>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Outputs[OLE DB Destination Error Output]"
+                          exclusionGroup="1"
+                          isErrorOut="true"
+                          name="OLE DB Destination Error Output"
+                          synchronousInputId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input]">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                    <component
+                      refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data"
+                      componentClassID="Microsoft.OLEDBSource"
+                      contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                      description="OLE DB Source"
+                      name="Get Supplier Data"
+                      usesDispositions="true"
+                      version="7">
+                      <properties>
+                        <property
+                          dataType="System.Int32"
+                          description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                          name="CommandTimeout">0</property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the name of the database object used to open a rowset."
+                          name="OpenRowset"></property>
+                        <property
+                          dataType="System.String"
+                          description="Specifies the variable that contains the name of the database object used to open a rowset."
+                          name="OpenRowsetVariable"></property>
+                        <property
+                          dataType="System.String"
+                          description="The SQL command to be executed."
+                          name="SqlCommand"
+                          UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT DISTINCT SupplierId, SupplierName
+  FROM dbo.[Order]
+ WHERE SupplierId IS NOT NULL;</property>
+                        <property
+                          dataType="System.String"
+                          description="The variable that contains the SQL command to be executed."
+                          name="SqlCommandVariable"></property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the column code page to use when code page information is unavailable from the data source."
+                          name="DefaultCodePage">1252</property>
+                        <property
+                          dataType="System.Boolean"
+                          description="Forces the use of the DefaultCodePage property value when describing character data."
+                          name="AlwaysUseDefaultCodePage">false</property>
+                        <property
+                          dataType="System.Int32"
+                          description="Specifies the mode used to access the database."
+                          name="AccessMode"
+                          typeConverter="AccessMode">2</property>
+                        <property
+                          dataType="System.String"
+                          description="The mappings between the parameters in the SQL command and variables."
+                          name="ParameterMapping"></property>
+                      </properties>
+                      <connections>
+                        <connection
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Connections[OleDbConnection]"
+                          connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                          description="The OLE DB runtime connection used to access the database."
+                          name="OleDbConnection" />
+                      </connections>
+                      <outputs>
+                        <output
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output]"
+                          name="OLE DB Source Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].Columns[SupplierId]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierId]"
+                              length="6"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].Columns[SupplierId]"
+                              name="SupplierId"
+                              truncationRowDisposition="FailComponent" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].Columns[SupplierName]"
+                              dataType="wstr"
+                              errorOrTruncationOperation="Conversion"
+                              errorRowDisposition="FailComponent"
+                              externalMetadataColumnId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierName]"
+                              length="255"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].Columns[SupplierName]"
+                              name="SupplierName"
+                              truncationRowDisposition="FailComponent" />
+                          </outputColumns>
+                          <externalMetadataColumns
+                            isUsed="True">
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierId]"
+                              dataType="wstr"
+                              length="6"
+                              name="SupplierId" />
+                            <externalMetadataColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[SupplierName]"
+                              dataType="wstr"
+                              length="255"
+                              name="SupplierName" />
+                          </externalMetadataColumns>
+                        </output>
+                        <output
+                          refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output]"
+                          isErrorOut="true"
+                          name="OLE DB Source Error Output">
+                          <outputColumns>
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[SupplierId]"
+                              dataType="wstr"
+                              length="6"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[SupplierId]"
+                              name="SupplierId" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[SupplierName]"
+                              dataType="wstr"
+                              length="255"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[SupplierName]"
+                              name="SupplierName" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                              name="ErrorCode"
+                              specialFlags="1" />
+                            <outputColumn
+                              refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              dataType="i4"
+                              lineageId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                              name="ErrorColumn"
+                              specialFlags="2" />
+                          </outputColumns>
+                          <externalMetadataColumns />
+                        </output>
+                      </outputs>
+                    </component>
+                  </components>
+                  <paths>
+                    <path
+                      refId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data.Paths[OLE DB Source Output]"
+                      endId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table.Inputs[OLE DB Destination Input]"
+                      name="OLE DB Source Output"
+                      startId="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data.Outputs[OLE DB Source Output]" />
+                  </paths>
+                </pipeline>
+              </DTS:ObjectData>
+            </DTS:Executable>
+          </DTS:Executables>
+          <DTS:PrecedenceConstraints>
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data.PrecedenceConstraints[Constraint]"
+              DTS:CreationName=""
+              DTS:DTSID="{950E69D5-4D18-4E22-95BF-00F527265702}"
+              DTS:From="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Supplier Addresses Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint"
+              DTS:To="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Suppliers Temp Table" />
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data.PrecedenceConstraints[Constraint 1]"
+              DTS:CreationName=""
+              DTS:DTSID="{7108D0C3-55F2-4F22-9B17-2945FF4F8457}"
+              DTS:From="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Supplier Addresses Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint 1"
+              DTS:To="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data" />
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Supplier Data\Migrate Base Supplier Data.PrecedenceConstraints[Constraint 2]"
+              DTS:CreationName=""
+              DTS:DTSID="{2CA959F1-82A5-4E2D-9CB3-B0454E05F10D}"
+              DTS:From="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Suppliers Temp Table"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint 2"
+              DTS:To="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data" />
+          </DTS:PrecedenceConstraints>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Supplier Data\Migrate Supplier Address Data"
+          DTS:CreationName="STOCK:FOREACHLOOP"
+          DTS:Description="Foreach Loop Container"
+          DTS:DTSID="{870869F7-29FA-4C45-89D1-315446F578F4}"
+          DTS:ExecutableType="STOCK:FOREACHLOOP"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Supplier Address Data">
+          <DTS:ForEachEnumerator
+            DTS:CreationName="Microsoft.ForEachADOEnumerator"
+            DTS:DTSID="{1C870C3D-0098-49C9-94DD-15830A94F599}"
+            DTS:ObjectName="{1C870C3D-0098-49C9-94DD-15830A94F599}">
+            <DTS:ObjectData>
+              <FEEADO
+                EnumType="EnumerateRowsInFirstTable"
+                VarName="User::supplierIDs" />
+            </DTS:ObjectData>
+          </DTS:ForEachEnumerator>
+          <DTS:Variables />
+          <DTS:Executables>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Supplier Data\Migrate Supplier Address Data\Add Supplier Address Data"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{32ef3ef6-1f0e-4bf4-abfc-6587f2440510}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Add Supplier Address Data"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::addSupplierAddressDataSql"
+                  SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+                  <SQLTask:ResultBinding
+                    SQLTask:ResultName="0"
+                    SQLTask:DtsVariableName="User::supplierIdentityValue" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="0"
+                    SQLTask:DtsVariableName="User::supplierId"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="130"
+                    SQLTask:ParameterSize="6" />
+                </SQLTask:SqlTaskData>
+              </DTS:ObjectData>
+            </DTS:Executable>
+            <DTS:Executable
+              DTS:refId="Package\Migrate Supplier Data\Migrate Supplier Address Data\Update Supplier Address ID"
+              DTS:CreationName="Microsoft.ExecuteSQLTask"
+              DTS:Description="Execute SQL Task"
+              DTS:DTSID="{29fda582-55ea-405c-a323-261779b39926}"
+              DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+              DTS:LocaleID="-1"
+              DTS:ObjectName="Update Supplier Address ID"
+              DTS:ThreadHint="0">
+              <DTS:Variables />
+              <DTS:ObjectData>
+                <SQLTask:SqlTaskData
+                  SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+                  SQLTask:SqlStmtSourceType="Variable"
+                  SQLTask:SqlStatementSource="User::updateSupplierAddressDataSql" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="0"
+                    SQLTask:DtsVariableName="User::supplierIdentityValue"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="3"
+                    SQLTask:ParameterSize="-1" />
+                  <SQLTask:ParameterBinding
+                    SQLTask:ParameterName="1"
+                    SQLTask:DtsVariableName="User::supplierId"
+                    SQLTask:ParameterDirection="Input"
+                    SQLTask:DataType="130"
+                    SQLTask:ParameterSize="6" />
+                </SQLTask:SqlTaskData>
+              </DTS:ObjectData>
+            </DTS:Executable>
+          </DTS:Executables>
+          <DTS:PrecedenceConstraints>
+            <DTS:PrecedenceConstraint
+              DTS:refId="Package\Migrate Supplier Data\Migrate Supplier Address Data.PrecedenceConstraints[Constraint]"
+              DTS:CreationName=""
+              DTS:DTSID="{BB2EF66C-48E4-446F-B6C9-578D61E6C69F}"
+              DTS:From="Package\Migrate Supplier Data\Migrate Supplier Address Data\Add Supplier Address Data"
+              DTS:LogicalAnd="True"
+              DTS:ObjectName="Constraint"
+              DTS:To="Package\Migrate Supplier Data\Migrate Supplier Address Data\Update Supplier Address ID" />
+          </DTS:PrecedenceConstraints>
+          <DTS:ForEachVariableMappings>
+            <DTS:ForEachVariableMapping
+              DTS:CreationName=""
+              DTS:DTSID="{5136F8E5-1F26-49E7-8960-25616239A396}"
+              DTS:ObjectName="{5136F8E5-1F26-49E7-8960-25616239A396}"
+              DTS:ValueIndex="0"
+              DTS:VariableName="User::supplierId" />
+          </DTS:ForEachVariableMappings>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Migrate Supplier Data\Persist Suppliers"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:DelayValidation="True"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{6E8FC0F5-B379-49AE-B739-27C335B7A8F3}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Persist Suppliers"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Get Temp Supplier Data"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable">User::suppliersTempTableName</property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">1</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping"></property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[Id]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[Id]"
+                          length="6"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[Id]"
+                          name="Id"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[Name]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[Name]"
+                          length="256"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[Name]"
+                          name="Name"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[AddressId]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[AddressId]"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[AddressId]"
+                          name="AddressId"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[Id]"
+                          dataType="wstr"
+                          length="6"
+                          name="Id" />
+                        <externalMetadataColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[Name]"
+                          dataType="wstr"
+                          length="256"
+                          name="Name" />
+                        <externalMetadataColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].ExternalColumns[AddressId]"
+                          dataType="i4"
+                          name="AddressId" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[Id]"
+                          dataType="wstr"
+                          length="6"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[Id]"
+                          name="Id" />
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[Name]"
+                          dataType="wstr"
+                          length="256"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[Name]"
+                          name="Name" />
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[AddressId]"
+                          dataType="i4"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[AddressId]"
+                          name="AddressId" />
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Insert Into Suppliers Table"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[dbo].[Supplier]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].Columns[Id]"
+                          cachedDataType="wstr"
+                          cachedLength="6"
+                          cachedName="Id"
+                          externalMetadataColumnId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[Id]" />
+                        <inputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].Columns[Name]"
+                          cachedDataType="wstr"
+                          cachedLength="256"
+                          cachedName="Name"
+                          externalMetadataColumnId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[Name]" />
+                        <inputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].Columns[AddressId]"
+                          cachedDataType="i4"
+                          cachedName="AddressId"
+                          externalMetadataColumnId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].ExternalColumns[AddressId]"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output].Columns[AddressId]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                          dataType="wstr"
+                          length="6"
+                          name="Id" />
+                        <externalMetadataColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          dataType="wstr"
+                          length="256"
+                          name="Name" />
+                        <externalMetadataColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input].ExternalColumns[AddressId]"
+                          dataType="i4"
+                          name="AddressId" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Migrate Supplier Data\Persist Suppliers.Paths[OLE DB Source Output]"
+                  endId="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+      </DTS:Executables>
+      <DTS:PrecedenceConstraints>
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Migrate Supplier Data.PrecedenceConstraints[Constraint 2]"
+          DTS:CreationName=""
+          DTS:DTSID="{484C402A-1C69-4045-9EC3-0179E7666200}"
+          DTS:From="Package\Migrate Supplier Data\Migrate Base Supplier Data"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 2"
+          DTS:To="Package\Migrate Supplier Data\Get Suppliers" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Migrate Supplier Data.PrecedenceConstraints[Constraint 3]"
+          DTS:CreationName=""
+          DTS:DTSID="{4B6A781D-D049-4B3A-8DB6-BFC15088633F}"
+          DTS:From="Package\Migrate Supplier Data\Get Suppliers"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 3"
+          DTS:To="Package\Migrate Supplier Data\Migrate Supplier Address Data" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Migrate Supplier Data.PrecedenceConstraints[Constraint 4]"
+          DTS:CreationName=""
+          DTS:DTSID="{69332E48-B271-4FE4-8D52-50EBAF3EE5FB}"
+          DTS:From="Package\Migrate Supplier Data\Migrate Supplier Address Data"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 4"
+          DTS:To="Package\Migrate Supplier Data\Persist Suppliers" />
+      </DTS:PrecedenceConstraints>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Sequence Container"
+      DTS:CreationName="STOCK:SEQUENCE"
+      DTS:Description="Sequence Container"
+      DTS:DTSID="{6A2FE83D-D65C-436D-B53D-D15965CE7021}"
+      DTS:ExecutableType="STOCK:SEQUENCE"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Sequence Container">
+      <DTS:Variables />
+      <DTS:Executables>
+        <DTS:Executable
+          DTS:refId="Package\Sequence Container\Migrate Catalogue Items"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{9BD12DE6-D7C4-40EA-9E69-24A4AB6608F3}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Catalogue Items"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Get Catalogue Items"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT DISTINCT CatalogueItemId, CatalogueItemTypeId, CatalogueItemName, ParentCatalogueItemId
+  FROM dbo.OrderItem;</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping"></property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                          length="14"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                          name="CatalogueItemId"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemName]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemName]"
+                          length="255"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemName]"
+                          name="CatalogueItemName"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[ParentCatalogueItemId]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[ParentCatalogueItemId]"
+                          length="14"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[ParentCatalogueItemId]"
+                          name="ParentCatalogueItemId"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemTypeId]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemTypeId]"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemTypeId]"
+                          name="CatalogueItemTypeId"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          name="CatalogueItemId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemName]"
+                          dataType="wstr"
+                          length="255"
+                          name="CatalogueItemName" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[ParentCatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          name="ParentCatalogueItemId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemTypeId]"
+                          dataType="i4"
+                          name="CatalogueItemTypeId" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                          name="CatalogueItemId" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemTypeId]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemTypeId]"
+                          name="CatalogueItemTypeId" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemName]"
+                          dataType="wstr"
+                          length="255"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[CatalogueItemName]"
+                          name="CatalogueItemName" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[ParentCatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[ParentCatalogueItemId]"
+                          name="ParentCatalogueItemId" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Insert Catalogue Items"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[dbo].[CatalogueItem]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].Columns[ParentCatalogueItemId]"
+                          cachedDataType="wstr"
+                          cachedLength="14"
+                          cachedName="ParentCatalogueItemId"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[ParentCatalogueItemId]"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[ParentCatalogueItemId]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].Columns[CatalogueItemTypeId]"
+                          cachedDataType="i4"
+                          cachedName="CatalogueItemTypeId"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemTypeId]"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemTypeId]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].Columns[CatalogueItemId]"
+                          cachedDataType="wstr"
+                          cachedLength="14"
+                          cachedName="CatalogueItemId"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemId]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].Columns[CatalogueItemName]"
+                          cachedDataType="wstr"
+                          cachedLength="255"
+                          cachedName="CatalogueItemName"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output].Columns[CatalogueItemName]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[Id]"
+                          dataType="wstr"
+                          length="14"
+                          name="Id" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemTypeId]"
+                          dataType="i4"
+                          name="CatalogueItemTypeId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          dataType="wstr"
+                          length="256"
+                          name="Name" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input].ExternalColumns[ParentCatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          name="ParentCatalogueItemId" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Sequence Container\Migrate Catalogue Items.Paths[OLE DB Source Output]"
+                  endId="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Sequence Container\Migrate Default Delivery Date"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{6C721C09-1D79-4CC0-AF48-49CED71B9A41}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Default Delivery Date"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Get Default Delivery Dates"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT CAST(SUBSTRING(d.OrderId, 3, 5) AS int) AS OrderId,
+       d.CatalogueItemId, d.DeliveryDate
+  FROM dbo.DefaultDeliveryDate AS d
+  INNER JOIN dbo.[Order] AS o
+    ON o.OrderId = d.OrderId
+  INNER JOIN dbo.OrderItem AS i
+    ON i.OrderId = o.OrderId
+   AND i.CatalogueItemId = d.CatalogueItemId;</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping"></property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[OrderId]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                          length="10"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[OrderId]"
+                          name="OrderId"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                          length="14"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[CatalogueItemId]"
+                          name="CatalogueItemId"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[DeliveryDate]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].ExternalColumns[DeliveryDate]"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[DeliveryDate]"
+                          name="DeliveryDate"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                          dataType="i4"
+                          name="OrderId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].ExternalColumns[CatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          name="CatalogueItemId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].ExternalColumns[DeliveryDate]"
+                          dataType="dbTimeStamp2"
+                          name="DeliveryDate"
+                          scale="7" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                          name="OrderId" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[CatalogueItemId]"
+                          name="CatalogueItemId" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[DeliveryDate]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[DeliveryDate]"
+                          name="DeliveryDate"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Insert Into DefaultDeliveryDate Table"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[dbo].[DefaultDeliveryDate]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].Columns[OrderId]"
+                          cachedDataType="wstr"
+                          cachedLength="10"
+                          cachedName="OrderId"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[OrderId]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].Columns[CatalogueItemId]"
+                          cachedDataType="wstr"
+                          cachedLength="14"
+                          cachedName="CatalogueItemId"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemId]"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[CatalogueItemId]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].Columns[DeliveryDate]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="DeliveryDate"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].ExternalColumns[DeliveryDate]"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output].Columns[DeliveryDate]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                          dataType="i4"
+                          name="OrderId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueItemId]"
+                          dataType="wstr"
+                          length="14"
+                          name="CatalogueItemId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input].ExternalColumns[DeliveryDate]"
+                          dataType="dbDate"
+                          name="DeliveryDate" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Sequence Container\Migrate Default Delivery Date.Paths[OLE DB Source Output]"
+                  endId="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Sequence Container\Migrate Order Progress"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{38B1B1F0-988A-42A5-877F-19C9DA96C4A7}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Order Progress"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Get Order Progress"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[dbo].[Order]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT CAST(SUBSTRING(OrderId, 3, 5) AS int) AS OrderId,
+       CatalogueSolutionsViewed,
+       AdditionalServicesViewed,
+       AssociatedServicesViewed
+  FROM dbo.[Order];</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping"></property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[OrderId]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                          length="10"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[OrderId]"
+                          name="OrderId"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[CatalogueSolutionsViewed]"
+                          dataType="bool"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[CatalogueSolutionsViewed]"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[CatalogueSolutionsViewed]"
+                          name="CatalogueSolutionsViewed"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[AdditionalServicesViewed]"
+                          dataType="bool"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[AdditionalServicesViewed]"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[AdditionalServicesViewed]"
+                          name="AdditionalServicesViewed"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[AssociatedServicesViewed]"
+                          dataType="bool"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[AssociatedServicesViewed]"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[AssociatedServicesViewed]"
+                          name="AssociatedServicesViewed"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[OrderId]"
+                          dataType="i4"
+                          name="OrderId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[CatalogueSolutionsViewed]"
+                          dataType="bool"
+                          name="CatalogueSolutionsViewed" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[AdditionalServicesViewed]"
+                          dataType="bool"
+                          name="AdditionalServicesViewed" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].ExternalColumns[AssociatedServicesViewed]"
+                          dataType="bool"
+                          name="AssociatedServicesViewed" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[OrderId]"
+                          name="OrderId" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[CatalogueSolutionsViewed]"
+                          dataType="bool"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[CatalogueSolutionsViewed]"
+                          name="CatalogueSolutionsViewed" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[AdditionalServicesViewed]"
+                          dataType="bool"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[AdditionalServicesViewed]"
+                          name="AdditionalServicesViewed" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[AssociatedServicesViewed]"
+                          dataType="bool"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[AssociatedServicesViewed]"
+                          name="AssociatedServicesViewed" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Insert Into OrderProgress Table"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[dbo].[OrderProgress]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].Columns[OrderId]"
+                          cachedDataType="wstr"
+                          cachedLength="10"
+                          cachedName="OrderId"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[OrderId]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].Columns[CatalogueSolutionsViewed]"
+                          cachedDataType="bool"
+                          cachedName="CatalogueSolutionsViewed"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueSolutionsViewed]"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[CatalogueSolutionsViewed]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].Columns[AdditionalServicesViewed]"
+                          cachedDataType="bool"
+                          cachedName="AdditionalServicesViewed"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[AdditionalServicesViewed]"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[AdditionalServicesViewed]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].Columns[AssociatedServicesViewed]"
+                          cachedDataType="bool"
+                          cachedName="AssociatedServicesViewed"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[AssociatedServicesViewed]"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output].Columns[AssociatedServicesViewed]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[OrderId]"
+                          dataType="i4"
+                          name="OrderId" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[CatalogueSolutionsViewed]"
+                          dataType="bool"
+                          name="CatalogueSolutionsViewed" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[AdditionalServicesViewed]"
+                          dataType="bool"
+                          name="AdditionalServicesViewed" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input].ExternalColumns[AssociatedServicesViewed]"
+                          dataType="bool"
+                          name="AssociatedServicesViewed" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Sequence Container\Migrate Order Progress.Paths[OLE DB Source Output]"
+                  endId="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Sequence Container\Migrate Order Progress\Get Order Progress.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Sequence Container\Migrate Pricing Units"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{A0B94167-B248-4DF1-9228-807D3A3CED4C}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Pricing Units"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Get Pricing Units"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT DISTINCT PricingUnitName,
+       CAST(REPLACE (PricingUnitDescription, ' - ', ' – ') AS nvarchar(40)) AS PricingUnitDescription
+  FROM dbo.OrderItem;</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping"></property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].Columns[PricingUnitName]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitName]"
+                          length="20"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].Columns[PricingUnitName]"
+                          name="PricingUnitName"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].Columns[PricingUnitDescription]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitDescription]"
+                          length="40"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].Columns[PricingUnitDescription]"
+                          name="PricingUnitDescription"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitName]"
+                          dataType="wstr"
+                          length="20"
+                          name="PricingUnitName" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].ExternalColumns[PricingUnitDescription]"
+                          dataType="wstr"
+                          length="40"
+                          name="PricingUnitDescription" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[PricingUnitName]"
+                          dataType="wstr"
+                          length="20"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[PricingUnitName]"
+                          name="PricingUnitName" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[PricingUnitDescription]"
+                          dataType="wstr"
+                          length="40"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[PricingUnitDescription]"
+                          name="PricingUnitDescription" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Insert Into PricingUnit Table"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[dbo].[PricingUnit]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input].Columns[PricingUnitName]"
+                          cachedDataType="wstr"
+                          cachedLength="20"
+                          cachedName="PricingUnitName"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].Columns[PricingUnitName]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input].Columns[PricingUnitDescription]"
+                          cachedDataType="wstr"
+                          cachedLength="40"
+                          cachedName="PricingUnitDescription"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input].ExternalColumns[Description]"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output].Columns[PricingUnitDescription]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          dataType="wstr"
+                          length="20"
+                          name="Name" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input].ExternalColumns[Description]"
+                          dataType="wstr"
+                          length="40"
+                          name="Description" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Sequence Container\Migrate Pricing Units.Paths[OLE DB Source Output]"
+                  endId="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Sequence Container\Migrate Service Recipients"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{F98541EE-1FEA-4498-ABF1-4573A4791227}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Service Recipients"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Get Service Recipients"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">SELECT DISTINCT o.OdsCode, s.[Name]
+  FROM dbo.[OrderItem] AS o
+       LEFT OUTER JOIN dbo.ServiceRecipient AS s
+       ON s.OdsCode = o.OdsCode;</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping"></property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Non-Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].Columns[OdsCode]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].ExternalColumns[OdsCode]"
+                          length="8"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].Columns[OdsCode]"
+                          name="OdsCode"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].Columns[Name]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].ExternalColumns[Name]"
+                          length="256"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].Columns[Name]"
+                          name="Name"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].ExternalColumns[OdsCode]"
+                          dataType="wstr"
+                          length="8"
+                          name="OdsCode" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].ExternalColumns[Name]"
+                          dataType="wstr"
+                          length="256"
+                          name="Name" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[OdsCode]"
+                          dataType="wstr"
+                          length="8"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[OdsCode]"
+                          name="OdsCode" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[Name]"
+                          dataType="wstr"
+                          length="256"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[Name]"
+                          name="Name" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Insert Into ServiceRecipients Table"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[dbo].[ServiceRecipient]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">TABLOCK,CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Connections[OleDbConnection]"
+                      connectionManagerID="Package.ConnectionManagers[Ordering_Bulk]"
+                      connectionManagerRefId="Package.ConnectionManagers[Ordering_Bulk]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input].Columns[OdsCode]"
+                          cachedDataType="wstr"
+                          cachedLength="8"
+                          cachedName="OdsCode"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input].ExternalColumns[OdsCode]"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].Columns[OdsCode]" />
+                        <inputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input].Columns[Name]"
+                          cachedDataType="wstr"
+                          cachedLength="256"
+                          cachedName="Name"
+                          externalMetadataColumnId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output].Columns[Name]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input].ExternalColumns[OdsCode]"
+                          dataType="wstr"
+                          length="8"
+                          name="OdsCode" />
+                        <externalMetadataColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input].ExternalColumns[Name]"
+                          dataType="wstr"
+                          length="256"
+                          name="Name" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Sequence Container\Migrate Service Recipients.Paths[OLE DB Source Output]"
+                  endId="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+      </DTS:Executables>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Set Order Item Default Delivery Date"
+      DTS:CreationName="Microsoft.ExecuteSQLTask"
+      DTS:Description="Execute SQL Task"
+      DTS:DTSID="{FE031DBE-C684-4795-B737-F1B037005AA3}"
+      DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Set Order Item Default Delivery Date"
+      DTS:ThreadHint="0">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <SQLTask:SqlTaskData
+          SQLTask:Connection="{AB9EDF11-0BA1-427F-81B4-77E9BEB4DB57}"
+          SQLTask:SqlStatementSource="UPDATE o&#xA;   SET DefaultDeliveryDate = d.DeliveryDate&#xA;  FROM dbo.OrderItem AS o&#xA;       INNER JOIN dbo.DefaultDeliveryDate AS d&#xA;               ON d.OrderId = o.OrderId&#xA;              AND d.CatalogueItemId = o.CatalogueItemId;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+      </DTS:ObjectData>
+    </DTS:Executable>
+  </DTS:Executables>
+  <DTS:PrecedenceConstraints>
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint]"
+      DTS:CreationName=""
+      DTS:DTSID="{118DB73E-E148-4DF1-957E-3144663890D7}"
+      DTS:From="Package\Migrate Organization Data"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint"
+      DTS:To="Package\Migrate Supplier Data" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 1]"
+      DTS:CreationName=""
+      DTS:DTSID="{B6222AF6-AFC7-4B5D-B195-9B0183253FBA}"
+      DTS:From="Package\Migrate Supplier Data"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 1"
+      DTS:To="Package\Migrate Orders" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 2]"
+      DTS:CreationName=""
+      DTS:DTSID="{2F50836F-E555-46A6-9157-1CE85DC1BB35}"
+      DTS:From="Package\Migrate Orders"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 2"
+      DTS:To="Package\Migrate Contact Data" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 3]"
+      DTS:CreationName=""
+      DTS:DTSID="{CC543B47-D3DA-4AC6-90F5-3223642F9EAE}"
+      DTS:From="Package\Migrate Contact Data"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 3"
+      DTS:To="Package\Sequence Container" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 4]"
+      DTS:CreationName=""
+      DTS:DTSID="{71A42069-87CB-4D2E-9786-9289A656E731}"
+      DTS:From="Package\Sequence Container"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 4"
+      DTS:To="Package\Migrate Order Items" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 5]"
+      DTS:CreationName=""
+      DTS:DTSID="{C562B889-3E77-4052-B6AD-ED4CCF0595DD}"
+      DTS:From="Package\Migrate Order Items"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 5"
+      DTS:To="Package\Set Order Item Default Delivery Date" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 6]"
+      DTS:CreationName=""
+      DTS:DTSID="{E82B3D86-E9E5-4D99-8F52-A77B7C9AA622}"
+      DTS:From="Package\Set Order Item Default Delivery Date"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 6"
+      DTS:To="Package\Delete Redundant Default Delivery Dates" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 7]"
+      DTS:CreationName=""
+      DTS:DTSID="{EE4645B8-AD81-4D8B-9F44-6B94A6BAC585}"
+      DTS:From="Package\Delete Redundant Default Delivery Dates"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 7"
+      DTS:To="Package\Add Price IDs" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 8]"
+      DTS:CreationName=""
+      DTS:DTSID="{5E079664-D609-41DE-B524-92AE9C076D88}"
+      DTS:From="Package\Add Price IDs"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 8"
+      DTS:To="Package\Make Price ID Non-nullable" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 9]"
+      DTS:CreationName=""
+      DTS:DTSID="{4233C964-081E-43EA-B2DE-7B7AA9A2395D}"
+      DTS:From="Package\Make Price ID Non-nullable"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 9"
+      DTS:To="Package\Migrate Order Item Recipients" />
+  </DTS:PrecedenceConstraints>
+  <DTS:DesignTimeProperties><![CDATA[<?xml version="1.0"?>
+<!--This CDATA section contains the layout information of the package. The section includes information such as (x,y) coordinates, width, and height.-->
+<!--If you manually edit this section and make a mistake, you can delete it. -->
+<!--The package will still be able to load normally but the previous layout information will be lost and the designer will automatically re-arrange the elements on the design surface.-->
+<Objects
+  Version="8">
+  <!--Each node below will contain properties that do not affect runtime behavior.-->
+  <Package
+    design-time-name="Package">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="128" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml">
+        <NodeLayout
+          Size="146,42"
+          Id="Package\Add Price IDs"
+          TopLeft="562.5,3391.5" />
+        <NodeLayout
+          Size="280,42"
+          Id="Package\Delete Redundant Default Delivery Dates"
+          TopLeft="495.5,3289.5" />
+        <NodeLayout
+          Size="213,42"
+          Id="Package\Make Price ID Non-nullable"
+          TopLeft="529,3493.5" />
+        <NodeLayout
+          Size="225,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table"
+          TopLeft="12.0000000000001,107.5" />
+        <NodeLayout
+          Size="256,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table"
+          TopLeft="304.5,209.5" />
+        <NodeLayout
+          Size="220,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Create Contacts Temp Table"
+          TopLeft="14.5,5.5" />
+        <NodeLayout
+          Size="220,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Create OrderContacts Temp Table"
+          TopLeft="305.5,27.5" />
+        <NodeLayout
+          Size="238,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Load Contact IDs Into Recordset"
+          TopLeft="5.50000000000006,209.5" />
+        <EdgeLayout
+          Id="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint]"
+          TopLeft="124.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint 4]"
+          TopLeft="124.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint 1]"
+          TopLeft="234.5,26.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="71,22"
+              Start="0,0"
+              End="63.5,22">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="31.5,0" />
+                  <mssgle:CubicBezierSegment
+                    Point1="31.5,0"
+                    Point2="35.5,0"
+                    Point3="35.5,4" />
+                  <mssgle:LineSegment
+                    End="35.5,18" />
+                  <mssgle:CubicBezierSegment
+                    Point1="35.5,18"
+                    Point2="35.5,22"
+                    Point3="39.5,22" />
+                  <mssgle:LineSegment
+                    End="63.5,22" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Contact Data\Copy Contact Data.PrecedenceConstraints[Constraint 2]"
+          TopLeft="415.5,69.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="17,140"
+              Start="0,0"
+              End="17,132.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,66" />
+                  <mssgle:CubicBezierSegment
+                    Point1="0,66"
+                    Point2="0,70"
+                    Point3="4,70" />
+                  <mssgle:LineSegment
+                    End="13,70" />
+                  <mssgle:CubicBezierSegment
+                    Point1="13,70"
+                    Point2="17,70"
+                    Point3="17,74" />
+                  <mssgle:LineSegment
+                    End="17,132.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="566,307"
+          Size="566,350"
+          Id="Package\Migrate Contact Data\Copy Contact Data"
+          TopLeft="5.50000000000006,5.5" />
+        <NodeLayout
+          Size="166,42"
+          Id="Package\Migrate Contact Data\Recreate Contacts\Add Contact Data"
+          TopLeft="49,5.5" />
+        <NodeLayout
+          Size="253,42"
+          Id="Package\Migrate Contact Data\Recreate Contacts\Update Order Contacts Temp Table"
+          TopLeft="5.50000000000003,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Contact Data\Recreate Contacts.PrecedenceConstraints[Constraint]"
+          TopLeft="132,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="264,205"
+          Size="264,248"
+          Id="Package\Migrate Contact Data\Recreate Contacts"
+          TopLeft="156.5,415.5" />
+        <NodeLayout
+          Size="250,42"
+          Id="Package\Migrate Contact Data\Update Orders Table with Contacts"
+          TopLeft="163.5,723.5" />
+        <EdgeLayout
+          Id="Package\Migrate Contact Data.PrecedenceConstraints[Constraint 2]"
+          TopLeft="288.5,355.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Contact Data.PrecedenceConstraints[Constraint 4]"
+          TopLeft="288.5,663.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="577,821"
+          Size="577,864"
+          Id="Package\Migrate Contact Data"
+          TopLeft="347,1955.5" />
+        <NodeLayout
+          Size="225,42"
+          Id="Package\Migrate Order Item Recipients"
+          TopLeft="523,3595.5" />
+        <NodeLayout
+          Size="177,42"
+          Id="Package\Migrate Order Items"
+          TopLeft="547,3085.5" />
+        <NodeLayout
+          Size="152,42"
+          Id="Package\Migrate Orders"
+          TopLeft="559.5,1853.5" />
+        <NodeLayout
+          Size="182,42"
+          Id="Package\Migrate Organization Data\Get Organization IDs"
+          TopLeft="209.5,415.5" />
+        <NodeLayout
+          Size="290,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data"
+          TopLeft="294.5,209.5" />
+        <NodeLayout
+          Size="228,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Create Addresses Temp Table"
+          TopLeft="17.5000000000001,14.5" />
+        <NodeLayout
+          Size="258,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Create Organization IDs Temp Table"
+          TopLeft="310.5,5.5" />
+        <NodeLayout
+          Size="207,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data"
+          TopLeft="336,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data.PrecedenceConstraints[Constraint]"
+          TopLeft="439.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data.PrecedenceConstraints[Constraint 1]"
+          TopLeft="439.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="590,307"
+          Size="590,350"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data"
+          TopLeft="5.50000000000006,5.5" />
+        <NodeLayout
+          Size="233,42"
+          Id="Package\Migrate Organization Data\Migrate Organization Address Data\Add Organization Address Data"
+          TopLeft="7.50000000000001,5.5" />
+        <NodeLayout
+          Size="237,42"
+          Id="Package\Migrate Organization Data\Migrate Organization Address Data\Update Organization Address ID"
+          TopLeft="5.50000000000001,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Organization Data\Migrate Organization Address Data.PrecedenceConstraints[Constraint]"
+          TopLeft="124,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="248,205"
+          Size="248,248"
+          Id="Package\Migrate Organization Data\Migrate Organization Address Data"
+          TopLeft="176.5,517.5" />
+        <EdgeLayout
+          Id="Package\Migrate Organization Data.PrecedenceConstraints[Constraint]"
+          TopLeft="300.5,355.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Organization Data.PrecedenceConstraints[Constraint 1]"
+          TopLeft="300.5,457.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="601,821"
+          Size="601,864"
+          Id="Package\Migrate Organization Data"
+          TopLeft="335,5.5" />
+        <NodeLayout
+          Size="146,42"
+          Id="Package\Migrate Supplier Data\Get Suppliers"
+          TopLeft="215.5,313.5" />
+        <NodeLayout
+          Size="268,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data"
+          TopLeft="7.5,107.5" />
+        <NodeLayout
+          Size="272,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Supplier Addresses Temp Table"
+          TopLeft="5.5,5.5" />
+        <NodeLayout
+          Size="222,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Create Suppliers Temp Table"
+          TopLeft="338.5,5.5" />
+        <NodeLayout
+          Size="185,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data"
+          TopLeft="357,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data.PrecedenceConstraints[Constraint 2]"
+          TopLeft="449.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data.PrecedenceConstraints[Constraint]"
+          TopLeft="277.5,26.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="61,0"
+              Start="0,0"
+              End="53.5,0">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="53.5,0" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data.PrecedenceConstraints[Constraint 1]"
+          TopLeft="141.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="566,205"
+          Size="566,248"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data"
+          TopLeft="5.50000000000006,5.5" />
+        <NodeLayout
+          Size="211,42"
+          Id="Package\Migrate Supplier Data\Migrate Supplier Address Data\Add Supplier Address Data"
+          TopLeft="7.50000000000001,5.5" />
+        <NodeLayout
+          Size="215,42"
+          Id="Package\Migrate Supplier Data\Migrate Supplier Address Data\Update Supplier Address ID"
+          TopLeft="5.50000000000001,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data\Migrate Supplier Address Data.PrecedenceConstraints[Constraint]"
+          TopLeft="113,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="226,205"
+          Size="226,248"
+          Id="Package\Migrate Supplier Data\Migrate Supplier Address Data"
+          TopLeft="175.5,415.5" />
+        <NodeLayout
+          Size="162,42"
+          Id="Package\Migrate Supplier Data\Persist Suppliers"
+          TopLeft="207.5,723.5" />
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data.PrecedenceConstraints[Constraint 2]"
+          TopLeft="288.5,253.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data.PrecedenceConstraints[Constraint 3]"
+          TopLeft="288.5,355.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data.PrecedenceConstraints[Constraint 4]"
+          TopLeft="288.5,663.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="577,821"
+          Size="577,864"
+          Id="Package\Migrate Supplier Data"
+          TopLeft="347,929.5" />
+        <NodeLayout
+          Size="199,42"
+          Id="Package\Sequence Container\Migrate Catalogue Items"
+          TopLeft="5.5,5.5" />
+        <NodeLayout
+          Size="223,42"
+          Id="Package\Sequence Container\Migrate Default Delivery Date"
+          TopLeft="265.5,5.5" />
+        <NodeLayout
+          Size="194,42"
+          Id="Package\Sequence Container\Migrate Order Progress"
+          TopLeft="549,5.5" />
+        <NodeLayout
+          Size="180,42"
+          Id="Package\Sequence Container\Migrate Pricing Units"
+          TopLeft="804,5.49999999999989" />
+        <NodeLayout
+          Size="210,42"
+          Id="Package\Sequence Container\Migrate Service Recipients"
+          TopLeft="1045,5.49999999999989" />
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="True"
+          PanelSize="1260,103"
+          Size="1260,146"
+          Id="Package\Sequence Container"
+          TopLeft="5.50000000000034,2879.5" />
+        <NodeLayout
+          Size="258,42"
+          Id="Package\Set Order Item Default Delivery Date"
+          TopLeft="506.5,3187.5" />
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint]"
+          TopLeft="635.5,869.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 1]"
+          TopLeft="635.5,1793.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 2]"
+          TopLeft="635.5,1895.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 3]"
+          TopLeft="635.5,2819.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 4]"
+          TopLeft="635.5,3025.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 5]"
+          TopLeft="635.5,3127.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 6]"
+          TopLeft="635.5,3229.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 7]"
+          TopLeft="635.5,3331.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 8]"
+          TopLeft="635.5,3433.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 9]"
+          TopLeft="635.5,3535.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </Package>
+  <TaskHost
+    design-time-name="Package\Add Price IDs">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="8" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="137,42"
+          Id="Package\Add Price IDs\Set Price ID"
+          TopLeft="26,209.5" />
+        <NodeLayout
+          Size="178,42"
+          Id="Package\Add Price IDs\Get Order Item Data"
+          TopLeft="5.50000000000001,5.5" />
+        <NodeLayout
+          Size="157,42"
+          Id="Package\Add Price IDs\Lookup Price ID"
+          TopLeft="16,107.5" />
+        <EdgeLayout
+          Id="Package\Add Price IDs.Paths[OLE DB Source Output]"
+          TopLeft="94.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Add Price IDs.Paths[Lookup Match Output]"
+          TopLeft="94.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="-48.19138671875,20.4453125,96.3827734375,11.609375"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Add Price IDs\Get Order Item Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Add Price IDs\Lookup Price ID">
+    <Properties>
+      <Property>
+        <Name>OverwriteParamsSQLProp</Name>
+        <Value
+          type="q2:string">false</Value>
+      </Property>
+      <Property>
+        <Name>UsedTableName</Name>
+        <Value
+          type="q3:string"></Value>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q4:string">0</Value>
+      </Property>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="236,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table"
+          TopLeft="5.50000000000001,107.5" />
+        <NodeLayout
+          Size="143,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts"
+          TopLeft="52,5.5" />
+        <EdgeLayout
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table.Paths[OLE DB Source Output]"
+          TopLeft="123.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Get Contacts">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Contact Data\Copy Contact Data\Copy Contacts to Temp Table\Insert Into Contacts Temp Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="267,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table"
+          TopLeft="5.50000000000003,107.5" />
+        <NodeLayout
+          Size="174,42"
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts"
+          TopLeft="52,5.5" />
+        <EdgeLayout
+          Id="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table.Paths[OLE DB Source Output]"
+          TopLeft="139,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Get Order Contacts">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Contact Data\Copy Contact Data\Copy Order Contacts to Temp Table\Insert Into Order Contacts Temp Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Order Item Recipients">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="161,42"
+          Id="Package\Migrate Order Item Recipients\Insert Recipients"
+          TopLeft="5.50000000000001,107.5" />
+        <NodeLayout
+          Size="151,42"
+          Id="Package\Migrate Order Item Recipients\Get Recipients"
+          TopLeft="10.5,5.5" />
+        <EdgeLayout
+          Id="Package\Migrate Order Item Recipients.Paths[OLE DB Source Output]"
+          TopLeft="86,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Order Item Recipients\Get Recipients">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Order Item Recipients\Insert Recipients">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Order Items">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="158,42"
+          Id="Package\Migrate Order Items\Get Order Items"
+          TopLeft="10,5.5" />
+        <NodeLayout
+          Size="167,42"
+          Id="Package\Migrate Order Items\Insert Order Items"
+          TopLeft="5.50000000000001,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Order Items.Paths[OLE DB Source Output]"
+          TopLeft="89,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Order Items\Get Order Items">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Order Items\Insert Order Items">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Orders">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="154,42"
+          Id="Package\Migrate Orders\Get Order Data"
+          TopLeft="23,5.5" />
+        <NodeLayout
+          Size="189,42"
+          Id="Package\Migrate Orders\Insert Into Order Table"
+          TopLeft="5.50000000000001,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Orders.Paths[OLE DB Source Output]"
+          TopLeft="100,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Orders\Get Order Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Orders\Insert Into Order Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="244,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table"
+          TopLeft="5.50000000000001,107.5" />
+        <NodeLayout
+          Size="166,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data"
+          TopLeft="43.5,5.5" />
+        <EdgeLayout
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data.Paths[OLE DB Source Output]"
+          TopLeft="127,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Get Address Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Organization Data\Migrate Base Organization Data\Add Temporary Organization Address Data\Insert Into Addresses Temp Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="8" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="123,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Multicast"
+          TopLeft="179,107.5" />
+        <NodeLayout
+          Size="198,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data"
+          TopLeft="5.50000000000006,209.5" />
+        <NodeLayout
+          Size="192,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table"
+          TopLeft="264.5,209.5" />
+        <NodeLayout
+          Size="188,42"
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data"
+          TopLeft="146.5,5.5" />
+        <EdgeLayout
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data.Paths[OLE DB Source Output]"
+          TopLeft="240.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data.Paths[Multicast Output 2]"
+          TopLeft="259.666666666667,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="100.833333333333,60"
+              Start="0,0"
+              End="100.833333333333,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,20.46227929374" />
+                  <mssgle:CubicBezierSegment
+                    Point1="0,20.46227929374"
+                    Point2="0,24.46227929374"
+                    Point3="4,24.46227929374" />
+                  <mssgle:LineSegment
+                    End="96.8333333333333,24.46227929374" />
+                  <mssgle:CubicBezierSegment
+                    Point1="96.8333333333333,24.46227929374"
+                    Point2="100.833333333333,24.46227929374"
+                    Point3="100.833333333333,28.46227929374" />
+                  <mssgle:LineSegment
+                    End="100.833333333333,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data.Paths[Multicast Output 1]"
+          TopLeft="221.333333333333,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="-116.833333333333,60"
+              Start="0,0"
+              End="-116.833333333333,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,20.46227929374" />
+                  <mssgle:CubicBezierSegment
+                    Point1="0,20.46227929374"
+                    Point2="0,24.46227929374"
+                    Point3="-4,24.46227929374" />
+                  <mssgle:LineSegment
+                    End="-112.833333333333,24.46227929374" />
+                  <mssgle:CubicBezierSegment
+                    Point1="-112.833333333333,24.46227929374"
+                    Point2="-116.833333333333,24.46227929374"
+                    Point3="-116.833333333333,28.46227929374" />
+                  <mssgle:LineSegment
+                    End="-116.833333333333,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Insert Organization Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Add IDs to Temp Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Organization Data\Migrate Base Organization Data\Migrate Organization Data\Get Organization Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml">
+        <NodeLayout
+          Size="288,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table"
+          TopLeft="5.50000000000003,107.5" />
+        <NodeLayout
+          Size="210,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data"
+          TopLeft="44.5,5.5" />
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data.Paths[OLE DB Source Output]"
+          TopLeft="149.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Get Supplier Address Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Supplier Data\Migrate Base Supplier Data\Add Temporary Supplier Address Data\Insert Into Supplier Addresses Temp Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml">
+        <NodeLayout
+          Size="166,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data"
+          TopLeft="43.5,5.5" />
+        <NodeLayout
+          Size="242,42"
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table"
+          TopLeft="5.50000000000001,107.5" />
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data.Paths[OLE DB Source Output]"
+          TopLeft="126.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Add Supplier Data to Temp Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Supplier Data\Migrate Base Supplier Data\Migrate Supplier Data\Get Supplier Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Migrate Supplier Data\Persist Suppliers">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="207,42"
+          Id="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table"
+          TopLeft="5.50000000000001,107.5" />
+        <NodeLayout
+          Size="197,42"
+          Id="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data"
+          TopLeft="10.5,5.5" />
+        <EdgeLayout
+          Id="Package\Migrate Supplier Data\Persist Suppliers.Paths[OLE DB Source Output]"
+          TopLeft="109,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Supplier Data\Persist Suppliers\Get Temp Supplier Data">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Migrate Supplier Data\Persist Suppliers\Insert Into Suppliers Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Sequence Container\Migrate Catalogue Items">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="180,42"
+          Id="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items"
+          TopLeft="10,5.5" />
+        <NodeLayout
+          Size="189,42"
+          Id="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items"
+          TopLeft="5.50000000000001,107.5" />
+        <EdgeLayout
+          Id="Package\Sequence Container\Migrate Catalogue Items.Paths[OLE DB Source Output]"
+          TopLeft="100,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Catalogue Items\Get Catalogue Items">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Catalogue Items\Insert Catalogue Items">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Sequence Container\Migrate Default Delivery Date">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="259,42"
+          Id="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table"
+          TopLeft="5.50000000000003,107.5" />
+        <NodeLayout
+          Size="209,42"
+          Id="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates"
+          TopLeft="30.5,5.5" />
+        <EdgeLayout
+          Id="Package\Sequence Container\Migrate Default Delivery Date.Paths[OLE DB Source Output]"
+          TopLeft="135,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Default Delivery Date\Get Default Delivery Dates">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Default Delivery Date\Insert Into DefaultDeliveryDate Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Sequence Container\Migrate Order Progress">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="175,42"
+          Id="Package\Sequence Container\Migrate Order Progress\Get Order Progress"
+          TopLeft="34.5,5.5" />
+        <NodeLayout
+          Size="233,42"
+          Id="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table"
+          TopLeft="5.50000000000001,107.5" />
+        <EdgeLayout
+          Id="Package\Sequence Container\Migrate Order Progress.Paths[OLE DB Source Output]"
+          TopLeft="122,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Order Progress\Get Order Progress">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Order Progress\Insert Into OrderProgress Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Sequence Container\Migrate Pricing Units">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="215,42"
+          Id="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table"
+          TopLeft="5.50000000000001,107.5" />
+        <NodeLayout
+          Size="161,42"
+          Id="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units"
+          TopLeft="32.5,5.5" />
+        <EdgeLayout
+          Id="Package\Sequence Container\Migrate Pricing Units.Paths[OLE DB Source Output]"
+          TopLeft="113,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Pricing Units\Get Pricing Units">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Pricing Units\Insert Into PricingUnit Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Sequence Container\Migrate Service Recipients">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="249,42"
+          Id="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table"
+          TopLeft="5.50000000000003,107.5" />
+        <NodeLayout
+          Size="191,42"
+          Id="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients"
+          TopLeft="34.5,5.5" />
+        <EdgeLayout
+          Id="Package\Sequence Container\Migrate Service Recipients.Paths[OLE DB Source Output]"
+          TopLeft="130,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Service Recipients\Get Service Recipients">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <PipelineComponentMetadata
+    design-time-name="Package\Sequence Container\Migrate Service Recipients\Insert Into ServiceRecipients Table">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+</Objects>]]></DTS:DesignTimeProperties>
+</DTS:Executable>

--- a/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/NHSD.BuyingCatalogue.Ordering.BulkMigration.database
+++ b/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/NHSD.BuyingCatalogue.Ordering.BulkMigration.database
@@ -1,0 +1,13 @@
+﻿<Database xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ddl2="http://schemas.microsoft.com/analysisservices/2003/engine/2" xmlns:ddl2_2="http://schemas.microsoft.com/analysisservices/2003/engine/2/2" xmlns:ddl100_100="http://schemas.microsoft.com/analysisservices/2008/engine/100/100" xmlns:ddl200="http://schemas.microsoft.com/analysisservices/2010/engine/200" xmlns:ddl200_200="http://schemas.microsoft.com/analysisservices/2010/engine/200/200" xmlns:ddl300="http://schemas.microsoft.com/analysisservices/2011/engine/300" xmlns:ddl300_300="http://schemas.microsoft.com/analysisservices/2011/engine/300/300" xmlns:ddl400="http://schemas.microsoft.com/analysisservices/2012/engine/400" xmlns:ddl400_400="http://schemas.microsoft.com/analysisservices/2012/engine/400/400" xmlns:ddl500="http://schemas.microsoft.com/analysisservices/2013/engine/500" xmlns:ddl500_500="http://schemas.microsoft.com/analysisservices/2013/engine/500/500" xmlns:dwd="http://schemas.microsoft.com/DataWarehouse/Designer/1.0" dwd:design-time-name="f5f6c0dd-8552-40d9-901c-a6e759889fe6" xmlns="http://schemas.microsoft.com/analysisservices/2003/engine">
+  <ID>NHSD.BuyingCatalogue.Ordering.BulkMigration</ID>
+  <Name>NHSD.BuyingCatalogue.Ordering.BulkMigration</Name>
+  <CreatedTimestamp>0001-01-01T00:00:00Z</CreatedTimestamp>
+  <LastSchemaUpdate>0001-01-01T00:00:00Z</LastSchemaUpdate>
+  <LastProcessed>0001-01-01T00:00:00Z</LastProcessed>
+  <State>Unprocessed</State>
+  <LastUpdate>0001-01-01T00:00:00Z</LastUpdate>
+  <DataSourceImpersonationInfo>
+    <ImpersonationMode>Default</ImpersonationMode>
+    <ImpersonationInfoSecurity>Unchanged</ImpersonationInfoSecurity>
+  </DataSourceImpersonationInfo>
+</Database>

--- a/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/NHSD.BuyingCatalogue.Ordering.BulkMigration.dtproj
+++ b/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/NHSD.BuyingCatalogue.Ordering.BulkMigration.dtproj
@@ -1,0 +1,468 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <DeploymentModel>Project</DeploymentModel>
+  <ProductVersion>15.0.2000.166</ProductVersion>
+  <SchemaVersion>9.0.1.0</SchemaVersion>
+  <State>$base64$PFNvdXJjZUNvbnRyb2xJbmZvIHhtbG5zOnhzZD0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOmRkbDI9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDAzL2VuZ2luZS8yIiB4bWxuczpkZGwyXzI9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDAzL2VuZ2luZS8yLzIiIHhtbG5zOmRkbDEwMF8xMDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDA4L2VuZ2luZS8xMDAvMTAwIiB4bWxuczpkZGwyMDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDEwL2VuZ2luZS8yMDAiIHhtbG5zOmRkbDIwMF8yMDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDEwL2VuZ2luZS8yMDAvMjAwIiB4bWxuczpkZGwzMDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDExL2VuZ2luZS8zMDAiIHhtbG5zOmRkbDMwMF8zMDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDExL2VuZ2luZS8zMDAvMzAwIiB4bWxuczpkZGw0MDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDEyL2VuZ2luZS80MDAiIHhtbG5zOmRkbDQwMF80MDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDEyL2VuZ2luZS80MDAvNDAwIiB4bWxuczpkZGw1MDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDEzL2VuZ2luZS81MDAiIHhtbG5zOmRkbDUwMF81MDA9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vYW5hbHlzaXNzZXJ2aWNlcy8yMDEzL2VuZ2luZS81MDAvNTAwIiB4bWxuczpkd2Q9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vRGF0YVdhcmVob3VzZS9EZXNpZ25lci8xLjAiPg0KICA8RW5hYmxlZD5mYWxzZTwvRW5hYmxlZD4NCiAgPFByb2plY3ROYW1lPjwvUHJvamVjdE5hbWU+DQogIDxBdXhQYXRoPjwvQXV4UGF0aD4NCiAgPExvY2FsUGF0aD48L0xvY2FsUGF0aD4NCiAgPFByb3ZpZGVyPjwvUHJvdmlkZXI+DQo8L1NvdXJjZUNvbnRyb2xJbmZvPg==</State>
+  <Database>
+    <Name>NHSD.BuyingCatalogue.Ordering.BulkMigration.database</Name>
+    <FullPath>NHSD.BuyingCatalogue.Ordering.BulkMigration.database</FullPath>
+  </Database>
+  <DataSources />
+  <DataSourceViews />
+  <DeploymentModelSpecificContent>
+    <Manifest>
+      <SSIS:Project SSIS:ProtectionLevel="DontSaveSensitive" xmlns:SSIS="www.microsoft.com/SqlServer/SSIS">
+        <SSIS:Properties>
+          <SSIS:Property SSIS:Name="ID">{c14d4632-0406-4fd7-b36b-a47a54e5bf4c}</SSIS:Property>
+          <SSIS:Property SSIS:Name="Name">NHSD.BuyingCatalogue.Ordering.BulkMigration</SSIS:Property>
+          <SSIS:Property SSIS:Name="VersionMajor">0</SSIS:Property>
+          <SSIS:Property SSIS:Name="VersionMinor">0</SSIS:Property>
+          <SSIS:Property SSIS:Name="VersionBuild">0</SSIS:Property>
+          <SSIS:Property SSIS:Name="VersionComments">
+          </SSIS:Property>
+          <SSIS:Property SSIS:Name="CreationDate">2021-05-20T12:54:46.4738863+01:00</SSIS:Property>
+          <SSIS:Property SSIS:Name="CreatorName">BJSS\christopher.martin</SSIS:Property>
+          <SSIS:Property SSIS:Name="CreatorComputerName">LPT4491</SSIS:Property>
+          <SSIS:Property SSIS:Name="Description">
+          </SSIS:Property>
+          <SSIS:Property SSIS:Name="FormatVersion">1</SSIS:Property>
+        </SSIS:Properties>
+        <SSIS:Packages>
+          <SSIS:Package SSIS:Name="Migrate.dtsx" SSIS:EntryPoint="1" />
+        </SSIS:Packages>
+        <SSIS:ConnectionManagers />
+        <SSIS:DeploymentInfo>
+          <SSIS:ProjectConnectionParameters />
+          <SSIS:PackageInfo>
+            <SSIS:PackageMetaData SSIS:Name="Migrate.dtsx">
+              <SSIS:Properties>
+                <SSIS:Property SSIS:Name="ID">{9F73416D-1D82-4D42-8777-E7030FF375E6}</SSIS:Property>
+                <SSIS:Property SSIS:Name="Name">Package</SSIS:Property>
+                <SSIS:Property SSIS:Name="VersionMajor">1</SSIS:Property>
+                <SSIS:Property SSIS:Name="VersionMinor">0</SSIS:Property>
+                <SSIS:Property SSIS:Name="VersionBuild">171</SSIS:Property>
+                <SSIS:Property SSIS:Name="VersionComments">
+                </SSIS:Property>
+                <SSIS:Property SSIS:Name="VersionGUID">{89EA8F7D-BD01-4B82-9C47-0C892922BF7A}</SSIS:Property>
+                <SSIS:Property SSIS:Name="PackageFormatVersion">8</SSIS:Property>
+                <SSIS:Property SSIS:Name="Description">
+                </SSIS:Property>
+                <SSIS:Property SSIS:Name="ProtectionLevel">0</SSIS:Property>
+              </SSIS:Properties>
+              <SSIS:Parameters>
+                <SSIS:Parameter SSIS:Name="DatabaseName_BuyingCatalogue">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">{01A4A307-CE48-4D56-B63F-F13E43519E0B}</SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">BuyingCatalogue</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="DatabaseName_Ordering_Bulk">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">{CC7BC7C2-17AD-424E-91E3-E983126A12E8}</SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">BuyingCatalogueOrdering_Bulk</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="DatabaseName_Ordering_Non_Bulk">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">{AD238A10-7C09-4B11-A5ED-503386803842}</SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">BuyingCatalogueOrdering_Non-Bulk</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="Host">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">{DE1EB755-3C39-4820-B7A2-59914BF36E14}</SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">localhost</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="Password">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">{76A71118-0FE5-4238-AE38-DD443DF8AEDA}</SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value" SSIS:Sensitive="1">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="UserName">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">{1CAB2FC2-2845-407F-9379-F26F8841FE3F}</SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">user_name</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.BuyingCatalogue.ConnectByProxy">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">false</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.BuyingCatalogue.ConnectionString">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">Data Source=localhost;User ID=user_name;Initial Catalog=BuyingCatalogue;Provider=SQLNCLI11.1;Auto Translate=False;</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.BuyingCatalogue.ConnectRetryCount">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">9</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.BuyingCatalogue.ConnectRetryInterval">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">5</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">9</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.BuyingCatalogue.ConnectUsingManagedIdentity">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">false</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.BuyingCatalogue.RetainSameConnection">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">false</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Bulk.ConnectByProxy">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">false</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Bulk.ConnectionString">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">Data Source=localhost;User ID=user_name;Initial Catalog=BuyingCatalogueOrdering_Bulk;Provider=SQLNCLI11.1;Auto Translate=False;</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Bulk.ConnectRetryCount">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">9</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Bulk.ConnectRetryInterval">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">5</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">9</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Bulk.ConnectUsingManagedIdentity">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">false</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Bulk.RetainSameConnection">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">true</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Non-Bulk.ConnectByProxy">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">false</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Non-Bulk.ConnectionString">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">Data Source=localhost;User ID=user_name;Initial Catalog=BuyingCatalogueOrdering_Non-Bulk;Provider=SQLNCLI11.1;Auto Translate=False;</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">18</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Non-Bulk.ConnectRetryCount">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">1</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">9</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Non-Bulk.ConnectRetryInterval">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">5</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">9</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Non-Bulk.ConnectUsingManagedIdentity">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">false</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+                <SSIS:Parameter SSIS:Name="CM.Ordering_Non-Bulk.RetainSameConnection">
+                  <SSIS:Properties>
+                    <SSIS:Property SSIS:Name="ID">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="CreationName">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="Description">
+                    </SSIS:Property>
+                    <SSIS:Property SSIS:Name="IncludeInDebugDump">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Required">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Sensitive">0</SSIS:Property>
+                    <SSIS:Property SSIS:Name="Value">true</SSIS:Property>
+                    <SSIS:Property SSIS:Name="DataType">3</SSIS:Property>
+                  </SSIS:Properties>
+                </SSIS:Parameter>
+              </SSIS:Parameters>
+            </SSIS:PackageMetaData>
+          </SSIS:PackageInfo>
+        </SSIS:DeploymentInfo>
+      </SSIS:Project>
+    </Manifest>
+  </DeploymentModelSpecificContent>
+  <ControlFlowParts />
+  <Miscellaneous />
+  <Configurations>
+    <Configuration>
+      <Name>Azure</Name>
+      <Options>
+        <OutputPath>bin</OutputPath>
+        <ConnectionMappings />
+        <ConnectionProviderMappings />
+        <ConnectionSecurityMappings />
+        <DatabaseStorageLocations />
+        <TargetServerVersion>SQLServer2017</TargetServerVersion>
+        <AzureMode>true</AzureMode>
+        <LinkedAzureTenantId />
+        <LinkedAzureAccountId />
+        <LinkedAzureSSISIR />
+        <LinkedAzureStorage />
+        <RemoteExecutionFolder />
+        <ParameterConfigurationValues>
+          <ConfigurationSetting>
+            <Id>LastModifiedTime</Id>
+            <Name>LastModifiedTime</Name>
+            <Value xsi:type="xsd:dateTime">2021-05-25T10:38:01.06682Z</Value>
+          </ConfigurationSetting>
+        </ParameterConfigurationValues>
+      </Options>
+    </Configuration>
+    <Configuration>
+      <Name>Development</Name>
+      <Options>
+        <OutputPath>bin</OutputPath>
+        <ConnectionMappings />
+        <ConnectionProviderMappings />
+        <ConnectionSecurityMappings />
+        <DatabaseStorageLocations />
+        <TargetServerVersion>SQLServer2017</TargetServerVersion>
+        <AzureMode>false</AzureMode>
+        <LinkedAzureTenantId />
+        <LinkedAzureAccountId />
+        <LinkedAzureSSISIR />
+        <LinkedAzureStorage />
+        <RemoteExecutionFolder />
+        <ParameterConfigurationValues>
+          <ConfigurationSetting>
+            <Id>LastModifiedTime</Id>
+            <Name>LastModifiedTime</Name>
+            <Value xsi:type="xsd:dateTime">2021-05-23T20:58:40.1426247Z</Value>
+          </ConfigurationSetting>
+        </ParameterConfigurationValues>
+      </Options>
+    </Configuration>
+  </Configurations>
+</Project>

--- a/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/NHSD.BuyingCatalogue.Ordering.BulkMigration.sln
+++ b/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/NHSD.BuyingCatalogue.Ordering.BulkMigration.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31313.79
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{159641D6-6404-4A2A-AE62-294DE0FE8301}") = "NHSD.BuyingCatalogue.Ordering.BulkMigration", "NHSD.BuyingCatalogue.Ordering.BulkMigration.dtproj", "{9E268261-FF3D-4529-AF5C-4F05AC70D185}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Azure|Default = Azure|Default
+		Development|Default = Development|Default
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9E268261-FF3D-4529-AF5C-4F05AC70D185}.Azure|Default.ActiveCfg = Azure
+		{9E268261-FF3D-4529-AF5C-4F05AC70D185}.Azure|Default.Build.0 = Azure
+		{9E268261-FF3D-4529-AF5C-4F05AC70D185}.Development|Default.ActiveCfg = Development
+		{9E268261-FF3D-4529-AF5C-4F05AC70D185}.Development|Default.Build.0 = Development
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4982B108-80F6-4422-A4D9-B9F161164A78}
+	EndGlobalSection
+EndGlobal

--- a/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/Project.params
+++ b/bulk-migration/NHSD.BuyingCatalogue.Ordering.BulkMigration/Project.params
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0"?>
+<SSIS:Parameters xmlns:SSIS="www.microsoft.com/SqlServer/SSIS" />


### PR DESCRIPTION
Activity: [AB#14702](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/14702)
Task: [AB#13126](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/13126)

Package is designed to migrate data from the non-bulk schema to a **clean** DB with the bulk schema. All databases are expected to be hosted on the same instance.

SQL Authorization is used and should be run under an admin account or an account that has `db_owner` permissions for the bulk schema DB and read permissions for the BAPI and non-bulk ORDAPI DBs.

Recommend deploying the project to SSISDB (integration services catalogue). The project can be removed from the catalogue and deleted from source following migration.